### PR TITLE
Proper packaging for PEP 420 namespace packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,25 @@
 import setuptools
 
 
+try:
+    from setuptools import find_namespace_packages
+except ImportError:
+    from setuptools import PEP420PackageFinder
+    find_namespace_packages = PEP420PackageFinder.find
+
 with open("README.md", "r") as fh:
         long_description = fh.read()
 
 setuptools.setup(
     name="conservator-cli",
-    version="0.0.2",
+    version="0.0.3",
     author="FLIR",
     author_email="someone@somewhere",
     description="Command-line tools using the FLIR Conservator API",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/FLIR/conservator-cli",
-    packages=["FLIR.conservator_cli.lib", "FLIR.conservator_cli.app"],
+    packages=find_namespace_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
setuptools.find_packages() does not work properly with PEP 420 style
of namespace packages. When doing normal 'pip install' rather than
'pip install -e' which merely links to an existing working dir,
the actual .py files were not getting packaged up.

The latest python packaging docs recommend setuptools.find_namespace_packages()
https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages
however that method seems to have been added recently. I found a fallback
method for supporting older setuptools on github, which seems to work fine.