### PR TITLE
Feature/integrate wordcloud

### DIFF
--- a/FLIR/conservator_cli/lib/graphql_api.py
+++ b/FLIR/conservator_cli/lib/graphql_api.py
@@ -224,7 +224,7 @@ def get_collection_by_id(id, access_token):
 	}
 	return query_conservator(query, variables, access_token)["collection"]
 
-def get_videos_by_collectionID(collectionID, access_token):
+def get_videos_by_collection_id(collection_id, access_token):
 	query = """
 	query videos($collectionId: ID!) {
 		videos(collectionId: $collectionId, limit:100000) {
@@ -236,7 +236,7 @@ def get_videos_by_collectionID(collectionID, access_token):
 	}
 	"""
 	variables = {
-		"collectionId": collectionID
+		"collectionId": collection_id
 	}
 	return query_conservator(query, variables, access_token)
 


### PR DESCRIPTION
Refactored conservator wordcloud code from FLIR/cortex repo to use new GraphQL APIs in conservator_cli. Added one additional GraphQL query to get all videos in a particular collection ID. 