### PR TITLE
graphql_api.py: display an invalid server response

### DIFF
--- a/FLIR/conservator_cli/lib/graphql_api.py
+++ b/FLIR/conservator_cli/lib/graphql_api.py
@@ -16,7 +16,11 @@ def query_conservator(query, variables, access_token):
 	graphql_endpoint = 'https://flirconservator.com/graphql'
 	headers = {'authorization': "{}".format(access_token) }
 	r = requests.post(graphql_endpoint, headers=headers, json={"query":query, "variables":variables})
-	response = r.json()
+	try:
+		response = r.json()
+	except:
+		raise ConservatorGraphQLServerError(
+			r.status_code, "Invalid server response", r.content)
 	if r.status_code not in (200, 201):
 		server_message = ""
 		if "errors" in response:


### PR DESCRIPTION
Improve debugging by showing the raw response from server if something other
than well-formed JSON is returned.

For instance, instead of this generic exception:
```
  json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

You might see this much more informative one:

```
  FLIR.conservator_cli.lib.graphql_api.ConservatorGraphQLServerError: (413,
  'Invalid server response', b'<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta
  charset="utf-8">\n<title>Error</title>\n</head>\n<body>\n<pre>Payload Too
  Large</pre>\n</body>\n</html>\n')
```

which makes it obvious the query failed due to being excessively large
(in above example, huge list of video ids that needed to be split into
multiple queries).