### PR TITLE
fix naming of metadata files

### DIFF
--- a/FLIR/conservator_cli/lib/fs_collection.py
+++ b/FLIR/conservator_cli/lib/fs_collection.py
@@ -97,7 +97,7 @@ class Collection:
             metadata = fca.get_video_metadata(video["id"], self.credentials.token)["metadata"]
             obj = json.loads(metadata)
             obj["videos"][0]["name"] = video["name"]
-            filename = ".".join(video["name"].split(".")[:-1] + ["json"])
+            filename = ".".join(video["filename"].split(".")[:-1] + ["json"])
             video_names.append(filename)
             if not dry_run:
                 with open(os.path.join(parent_folder, "video_metadata", filename), "w") as file:

--- a/FLIR/conservator_cli/lib/graphql_api.py
+++ b/FLIR/conservator_cli/lib/graphql_api.py
@@ -352,6 +352,7 @@ def get_videos_from_collection(collection_id, access_token):
 	  getFirstNVideos(id: $id, n: $n, searchText: $searchText) {
 	  	id
 		name
+		filename
 		url
 		tags
 		framesCount


### PR DESCRIPTION
Videos have both "name" and "filename" attributes in Conservator.
It is the "filename" attribute that can be expected to have a file suffix
according to filetype (for instance ".mp4" or ".avi"), so that should
work with the current scheme for naming downloaded metadata after the
corresponding video:

  some-video.mp4 -> video_metadata/some-video.json
  other-video.mp4 -> video_metadata/other-video.json

The video "name" defaults to same as "filename" so using "name" worked
for projects that left the default names alone, but the result was not so
useful for projects that gave videos non-default names that no longer
included a suffix:

  some-video -> video_metadata/json
  other-video -> video_metadata/json

meaning, the same "video_metadata/json" file kept getting overwritten,
ending up with just one set of metadata actually downloaded (the last
one processed).

Thus, metadata filename will now be generated based on the "filename"
attribute of the corresponding video, not on its "name" attribute.