### PR TITLE
Query robustness

### DIFF
--- a/FLIR/conservator_cli/lib/graphql_api.py
+++ b/FLIR/conservator_cli/lib/graphql_api.py
@@ -23,18 +23,28 @@ def query_conservator(query, variables, access_token, retry_delay=RETRY_DELAY, m
 	headers = {'authorization': "{}".format(access_token) }
 	response = {}
 
+	last_exception = None
 	for attempt in range(0, max_retries):
 		# request can fail with flaky network connections;
 		# parsing can fail if server responds, but with an http error
 		try:
 			r = requests.post(graphql_endpoint, headers=headers, json={"query":query, "variables":variables})
 			response = r.json()
+			last_exception = None
 			break
-		except:
+		# Bail out on signal exceptions.
+		except KeyboardInterrupt:
+			raise
+		except Exception as exc:
+		    # Capture exception to re-throw it later.
+			last_exception = exc
 			pass
 
 		# something went wrong, wait before retrying
 		time.sleep(retry_delay)
+
+	if last_exception is not None:
+		raise last_exception
 
 	# response with 'data' but not 'errors' means valid results
 	if response.get("errors"):


### PR DESCRIPTION
* Implement retries for graphql queries instead of failing from brief network failures
  * tunable number of retries
  * tunable delay between attempts
  * both parameters are optional, default being up to 10 attempts with 1 sec inbetween
* work around bug in conservator per-folder media counts that cuts off results for large folders
  * get_*_filelist() functions were using paged queries, so just keep incrementing to next page until hitting an empty page (rather than calculating expected number of pages from possibly wrong count)