### PR TITLE
Paged queries

### DIFF
--- a/FLIR/conservator_cli/lib/graphql_api.py
+++ b/FLIR/conservator_cli/lib/graphql_api.py
@@ -273,13 +273,15 @@ def get_media_from_id(media_id, access_token):
 		result = get_image_from_id(media_id, access_token)
 	return result
 
-##-------------------------
-## list files in collection
-##-------------------------
+##----------------------------
+## query media in a collection
+##----------------------------
 
+# WARNING: there is currently a Conservator bug where the non-recursive
+#          counts can be too small, so don't trust them too much...
 def get_media_counts(collection_id, access_token):
 	query = """
-	query imageCountRecursive($id: ID!) {
+	query mediaCountRecursive($id: ID!) {
 		collection(id: $id) {
 			recursiveVideoCount
 			videoCount
@@ -294,23 +296,24 @@ def get_media_counts(collection_id, access_token):
 	return query_conservator(query, variables, access_token)["collection"]
 
 # function generator with common code to be specialized for media type
-def funcgen_get_x_filelist(media_type):
-	def get_x_filelist(collection_id, access_token):
+# and list of media object fields to be returned
+def funcgen_paged_query(media_type, query_list):
+	def paged_query(collection_id, access_token):
 		medias = media_type + "s"          # e.g. "videos" or "images"
-		page_size = 200   # number of entries returned per query 
+		page_size = 200   # number of entries returned per query
+		query_fields = "\n".join(query_list) # fields of interest, e.g. "id" or "name"
 
 		result = []
 		page_result = []
 		page_offset = 0
 		while True:
 			query = """
-			query filenames($id: ID!, $limit: Int, $page: Int) {{
+			query paged_query($id: ID!, $limit: Int, $page: Int) {{
 				{medias}(collectionId: $id, limit: $limit, page: $page) {{
-				filename
-				url
+				{query_fields}
 			  }}
 			}}
-			""".format(medias=medias)
+			""".format(medias=medias, query_fields=query_fields)
 			variables = {
 				"id": collection_id,
 				"limit": page_size,
@@ -324,13 +327,17 @@ def funcgen_get_x_filelist(media_type):
 			else:
 				break
 		return result
-	return get_x_filelist
+	return paged_query
+
+##
+## get_*_filelist: list files with url
+##
 
 # generate query function for videos
-get_video_filelist = funcgen_get_x_filelist("video")
+get_video_filelist = funcgen_paged_query("video", ["id", "filename", "url"])
 
 # generate query function for images
-get_image_filelist = funcgen_get_x_filelist("image")
+get_image_filelist = funcgen_paged_query("image", ["id", "filename", "url"])
 
 # query including both videos AND images
 def get_media_filelist(collection_id, access_token):
@@ -338,35 +345,24 @@ def get_media_filelist(collection_id, access_token):
 	images = get_image_filelist(collection_id, access_token)
 	return videos + images
 
-##--------------------
-## query by collection
-##--------------------
-
-# function generator with common code to be specialized for media type
-def funcgen_get_x_by_collection_id(media_type):
-	def get_x_by_collection_id(collection_id, access_token):
-		medias = media_type + "s" # e.g. "videos" or "images"
-		query = """
-		query {medias}($collectionId: ID!) {{
-			{medias}(collectionId: $collectionId, limit:100000) {{
-				id 
-				filename
-				url
-				tags
-			}} 
-		}}
-		""".format(medias=medias)
-		variables = {
-			"collectionId": collection_id
-		}
-		return query_conservator(query, variables, access_token)
-	return get_x_by_collection_id
+##
+## get_*_by_collection_id: list files with url and tags
+##                         note result list is returned as field in a dict
+##
 
 # generate query function for videos
-get_videos_by_collection_id = funcgen_get_x_by_collection_id("video")
+get_videos_by_collection_id_helper = funcgen_paged_query("video", ["id", "filename", "url", "tags"])
+
+def get_videos_by_collection_id(collection_id, access_token):
+	video_list = get_videos_by_collection_id_helper(collection_id, access_token) 
+	return {"videos": video_list}
 
 # generate query function for images
-get_images_by_collection_id = funcgen_get_x_by_collection_id("image")
+get_images_by_collection_id_helper = funcgen_paged_query("image", ["id", "filename", "url", "tags"])
+
+def get_images_by_collection_id(collection_id, access_token):
+	image_list = get_images_by_collection_id_helper(collection_id, access_token) 
+	return {"images": image_list}
 
 # query including both videos AND images
 def get_media_by_collection_id(collection_id, access_token):
@@ -376,35 +372,15 @@ def get_media_by_collection_id(collection_id, access_token):
 	media = {"media": videos["videos"] + images["images"]}
 	return media
 
-# function generator with common code to be specialized for media type
-def funcgen_get_x_from_collection(media_type):
-	def get_x_from_collection(collection_id, access_token):
-		first = "getFirstN" + media_type.capitalize() + "s" # e.g. "getFirstNVideos" or "getFirstNImages"
-		query = """
-		query {first}($id: ID!, $n: Int, $searchText: String) {{
-		  {first}(id: $id, n: $n, searchText: $searchText) {{
-		  	id
-			name
-			filename
-			url
-			tags
-			framesCount
-		  }}
-		}}
-		""".format(first=first)
-		variables = {
-			"id": collection_id,
-			"n":1000,
-			"searchText":""
-		}
-		return query_conservator(query, variables, access_token)[first]
-	return get_x_from_collection
+##
+## get_*_from_collection: list files with url, tags, and number of frames
+##
 
 # generate query function for videos
-get_videos_from_collection = funcgen_get_x_from_collection("video")
+get_videos_from_collection = funcgen_paged_query("video", ["id", "filename", "url", "tags", "framesCount"])
 
 # generate query function for images
-get_images_from_collection = funcgen_get_x_from_collection("image")
+get_images_from_collection = funcgen_paged_query("image", ["id", "filename", "url", "tags", "framesCount"])
 
 # query including both videos AND images
 def get_media_from_collection(collection_id, access_token):


### PR DESCRIPTION
graphql_api.py: paged queries for media in collection

The paged API query code previously used to implement get_*_filelist()
has been extracted out as common code for the other 2 sets of queries
on media inside a given collection:
* get_*_by_collection_id()
* get_*_from_collection()

The main difference between the 3 sets of functions is which fields are
included in the query results, which is handled by passing in the field list
to the function generator.

The other difference was that get_*_by_collection_id() functions use a slightly
different format for results; the results are returned inside a dictionary
instead of just the list itself

get_videos_by_collection_id() -> {"videos": [...]}
get_images_by_collection_id() -> {"images": [...]}
