### PR TITLE
rename run_task plugin: conservator_download_folder -> download_collection

### DIFF
--- a/FLIR/conservator_cli/configs/download_collection.json
+++ b/FLIR/conservator_cli/configs/download_collection.json
@@ -14,7 +14,7 @@
     {
       "name": "download_folder",
       "description": "Download folder from Conservator",
-      "task_type": "conservator_download_folder",
+      "task_type": "download_collection",
       "depends": ["get_creds"],
       "task_config": {
         "local_folder": "/mnt/data/local_datasets/download_folder_test",

--- a/FLIR/conservator_cli/run_tasks_plugins/download_collection.py
+++ b/FLIR/conservator_cli/run_tasks_plugins/download_collection.py
@@ -6,7 +6,7 @@ import blessed
 
 t = blessed.Terminal()
 
-def conservator_download_folder(credentials, local_folder, conservator_folder, 
+def download_collection(credentials, local_folder, conservator_folder, 
                                 include_datasets=False, include_video_metadata=False, 
                                 include_associated_files=False, include_media=False,
                                 delete=False, task=None):
@@ -20,4 +20,4 @@ def conservator_download_folder(credentials, local_folder, conservator_folder,
         print(e)
         return False
 
-exports = [conservator_download_folder]
+exports = [download_collection]

--- a/FLIR/conservator_cli/run_tasks_plugins/valid_tasks.json
+++ b/FLIR/conservator_cli/run_tasks_plugins/valid_tasks.json
@@ -2,6 +2,6 @@
   "python_modules": [
     "$NTKROOT/task_runner/FLIR/task_runner/run_tasks_plugins/define_config.py",
     "$NTKROOT/conservator-cli/FLIR/conservator_cli/run_tasks_plugins/load_credentials.py",
-    "$NTKROOT/conservator-cli/FLIR/conservator_cli/run_tasks_plugins/conservator_download_folder.py"
+    "$NTKROOT/conservator-cli/FLIR/conservator_cli/run_tasks_plugins/download_collection.py"
   ]
 }


### PR DESCRIPTION
ConservatorTools repo is using the name 'conservator_download_folder'
for a different task that takes different parameters. Oops.
Changing this one to 'download_collection' since that's more consistent
with the naming conventions here anyways, talking about collections
instead of folders.