### PR TITLE
Add actions to verify and deploy docs

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "docs/"
+    # Publish built docs to gh-pages branch.
+    # ===============================
+    - name: Commit documentation changes
+      run: |
+        git clone https://github.com/FLIR/conservator-cli.git --branch gh-pages --single-branch gh-pages
+        cp -r docs/_build/html/* gh-pages/
+        cd gh-pages
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add .
+        git commit -m "Update documentation" -a || true
+        # The above command will fail if no changes were present, so we ignore that.
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        branch: gh-pages
+        directory: gh-pages
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    # ===============================

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,15 @@
+# Verify that the docs build correctly
+name: Pull Request Docs Check
+
+  on: [ pull_request ]
+
+  jobs:
+    build:
+
+      runs-on: ubuntu-latest
+
+      steps:
+        - uses: actions/checkout@v1
+        - uses: ammaraskar/sphinx-action@master
+          with:
+            docs-folder: "docs/"


### PR DESCRIPTION
This adds two new Github actions:

On any pull request:
 - Attempt to build docs
 - Reject PR if docs fail to build

On any push to master:
 - Build docs
 - Copy to `gh-pages` branch
 - Push `gh-pages` branch

The `gh-pages` branch will be hosted by Github Pages.

Probably made some mistakes in here and this might take a few attempts to get working.
