### PR TITLE
Only use Lime Jenkins executor for now

### DIFF
--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -1,5 +1,5 @@
 pipeline {
-  agent {label "ubuntu && desktop"}
+  agent {label "ubuntu && desktop && jenkins-caffe"}
   stages {
     stage('Install') {
       steps {


### PR DESCRIPTION
Seems that just `ubuntu && desktop` matches some executors that don't have the correct python/pip/virtualenv setup installed.  Reverting to just `lime` until that is fixed