### PR TITLE
Add ability to clone from commit hash

### DIFF
--- a/FLIR/conservator/cli/managers.py
+++ b/FLIR/conservator/cli/managers.py
@@ -97,10 +97,11 @@ def get_manager_command(type_manager, sgqlc_type, name):
         )
         @click.argument("id")
         @click.argument("path", default=".")
-        def clone(id, path):
+        @click.option("--checkout", help="Commit hash to checkout after clone")
+        def clone(id, path, checkout):
             dataset = get_instance().from_id(id)
             try:
-                dataset.clone(path)
+                dataset.clone(path, commit=checkout)
             except MissingFieldException:
                 click.secho(
                     "Dataset is missing a required field. It may not have an associated repository.",

--- a/FLIR/conservator/wrappers/dataset.py
+++ b/FLIR/conservator/wrappers/dataset.py
@@ -124,12 +124,15 @@ class Dataset(QueryableType):
         return f"{self._conservator.get_authenticated_url()}/dvc"
 
     @requires_fields("name", "repository.master")
-    def clone(self, path="."):
+    def clone(self, path=".", commit=None):
         """Clone this Dataset into a subdirectory of `path` based on
         the Dataset's name.
 
         For instance, if you pass ``path="~/Desktop"``, and want to download a Dataset
         called ``MyFirstDataset``, it will be cloned into ``~/Desktop/MyFirstDataset``.
+
+        :param path: If specified, the path to the parent directory to clone into.
+        :param commit: If specified, a specific commit hash to checkout after cloning.
         """
         path = os.path.join(path, self.name)
         if os.path.exists(path):
@@ -137,6 +140,10 @@ class Dataset(QueryableType):
 
         url = self.get_git_url()
         subprocess.call(["git", "clone", url, path])
+        if commit is not None:
+            os.chdir(path)
+            subprocess.call(["git", "reset", "--hard", commit])
+            os.chdir("..")
 
     @classmethod
     def from_local_path(cls, conservator, path="."):

--- a/docs/usage/cli_quickstart.rst
+++ b/docs/usage/cli_quickstart.rst
@@ -98,6 +98,10 @@ Cloning a dataset creates a local github repo. ``cd`` inside, and you'll find tw
 ``index.json``. This contains the video, image, and frame data that are a part of the
 dataset. It also includes annotations, a description, and more.
 
+It's also possible to clone a dataset from a specific commit using the ``--checkout`` option::
+
+    $ conservator datasets clone YOUR_DATASET_ID --checkout A_COMMIT_HASH
+
 Nowhere in this initial repo are any of the actual media objects. To download those, you'll
 need to use the ``pull`` command::
 


### PR DESCRIPTION
Added ``--checkout`` option to ``conservator datasets clone`` command.