### PR TITLE
Add md5 cache for datasets to speed up downloads.

### DIFF
--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -314,7 +314,7 @@ class LocalDataset:
             assets.append(asset)
 
         results = download_files(assets, process_count)
-        
+
         for link in links:
             dest, src = link
             logger.debug(f"Linking '{src}' to '{dest}'")


### PR DESCRIPTION
Should be effectively the same as the cache in `cvc.py`.

Closes #98 

Note: The "cache" is on a per-dataset basis, and doesn't exist when downloading collection images/videos. We might want to add options to "bundle" the caches of multiple datasets, and add support for a similar "cache" when downloading a Collection.
