### PR TITLE
Add recursive gets for collections, media

### DIFF
--- a/examples/list_files_recursively.py
+++ b/examples/list_files_recursively.py
@@ -1,5 +1,10 @@
 from FLIR.conservator.conservator import Conservator
 
+# Unless you want to keep the media with the collections
+# to be able to print the paths as in this example,
+# `recursively_get_media` is a one-liner that returns
+# all media recursively in a collection.
+
 conservator = Conservator.default()
 
 path = "/AndresTest"
@@ -7,14 +12,16 @@ path = "/AndresTest"
 starting_collection = conservator.collections.from_remote_path(
     path, fields=["path", "id"]
 )
-collections = [starting_collection]
+children = starting_collection.recursively_get_children(fields=["path", "id"])
 
-while len(collections) > 0:
-    collection = collections.pop()
+all_collections = [starting_collection, *children]
+for collection in all_collections:
     path = collection.path
     for video in collection.get_videos(fields=["name", "id"]):
         print(path + "/" + video.name)
-    for image in collection.get_videos(fields=["name", "id"]):
+    for image in collection.get_images(fields=["name", "id"]):
         print(path + "/" + image.name)
-    collection.populate(["children.path", "children.id"])
-    collections.extend(collection.children)
+
+# To just print the names, using recursively_get_media:
+for media in starting_collection.recursively_get_media(fields="name"):
+    print(media.name)


### PR DESCRIPTION
Because recursively listing images requires a ton of PaginatedQueries that would be impossible to expose well,
these methods iterate through them all for you using the provided fields and `yield from`. So these functions are generators.

You'll have to do individual queries yourself if you want more control using `Collection.recursively_get_children`--see example

