### PR TITLE
Remove --log-level from cvc subcommand of conservator

### DIFF
--- a/FLIR/conservator/cli/__init__.py
+++ b/FLIR/conservator/cli/__init__.py
@@ -12,7 +12,7 @@ from FLIR.conservator.managers import (
     ImageManager,
 )
 from FLIR.conservator.util import to_clean_string
-from FLIR.conservator.cli.cvc import main as cvc
+from FLIR.conservator.cli.cvc import cvc
 import logging
 
 

--- a/FLIR/conservator/cli/cvc.py
+++ b/FLIR/conservator/cli/cvc.py
@@ -202,5 +202,23 @@ def publish(local_dataset, message):
     local_dataset.push_commits()
 
 
+@click.group(help="Commands for manipulating local datasets")
+@click.option(
+    "-p", "--path", default=".", help="Path to dataset, defaults to current directory"
+)
+@click.pass_context
+def cvc(ctx, path):
+    # This command is added to conservator CLI.
+    # It is the same as main sans the log level stuff.
+    # The conservator command handles logging, and would
+    # result in confusing behavior if included twice.
+    conservator = Conservator.default()
+    ctx.obj = LocalDataset(conservator, path)
+
+
+# Hacky way to "add" commands to both groups
+cvc.commands = main.commands
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Option still exists on standalone `cvc` command--removed from `conservator cvc` because it interfered with the root log level option