### PR TITLE
Change when ID is included, test ID exists

### DIFF
--- a/FLIR/conservator/fields_request.py
+++ b/FLIR/conservator/fields_request.py
@@ -163,7 +163,7 @@ class FieldsRequest:
 
 def get_attr_by_path(path, obj):
     for subpath in path.split("."):
-        if "id" in obj:
+        if hasattr(obj, "id"):
             obj.id()
         obj = getattr(obj, subpath)
     return obj


### PR DESCRIPTION
Rather hacky solution...

Works because of the following:
 - default included fields always includes id
 - any object that isnt default-included will have been accessed using get_attr_by_path
 - get_attr_by_path goes through every object in the path, and now adds id if it exists
