### PR TITLE
Make file download progress display optional

### DIFF
--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -270,6 +270,7 @@ class LocalDataset:
         include_eight_bit=True,
         process_count=10,
         use_symlink=False,
+        no_meter=False,
     ):
         """
         Downloads the files listed in ``index.json`` of the local dataset.
@@ -280,6 +281,7 @@ class LocalDataset:
             will use `os.cpu_count()`.
         :param use_symlink: If `True`, use symbolic links instead of hardlinks when linking the
             cache and data.
+        :param no_meter: If 'True', don't display file download progress meters
         """
         if include_eight_bit:
             os.makedirs(self.data_path, exist_ok=True)
@@ -326,7 +328,7 @@ class LocalDataset:
             logger.debug(f"Going to download {md5}")
             assets.append(asset)
 
-        results = download_files(assets, process_count)
+        results = download_files(assets, process_count, no_meter=no_meter)
 
         for link in links:
             dest, src = link

--- a/FLIR/conservator/util.py
+++ b/FLIR/conservator/util.py
@@ -54,7 +54,7 @@ class FileDownloadException(Exception):
     pass
 
 
-def download_file(path, name, url, silent=False):
+def download_file(path, name, url, silent=False, no_meter=False):
     path = os.path.abspath(path)
     os.makedirs(path, exist_ok=True)
     r = requests.get(url, stream=True, allow_redirects=True)
@@ -66,7 +66,7 @@ def download_file(path, name, url, silent=False):
             return False
     size = int(r.headers["content-length"])
     size_mb = int(size / 1024 / 1024)
-    progress = tqdm.tqdm(total=size)
+    progress = tqdm.tqdm(total=size, disable=no_meter)
     progress.set_description(f"Downloading {name} ({size_mb:.2f} MB)")
     chunk_size = 1024 * 1024
     with open(os.path.join(path, name), "wb") as fd:
@@ -83,10 +83,10 @@ def upload_file(path, url):
         return requests.put(url, f)
 
 
-def download_files(files, process_count=None):
+def download_files(files, process_count=None, no_meter=False):
     # files = (path, name, url)
     pool = multiprocessing.Pool(process_count)  # defaults to CPU count
-    args = [(*file, True) for i, file in enumerate(files)]
+    args = [(*file, True, no_meter) for i, file in enumerate(files)]
     results = pool.starmap(download_file, args)
     return results
 

--- a/FLIR/conservator/wrappers/collection.py
+++ b/FLIR/conservator/wrappers/collection.py
@@ -255,20 +255,20 @@ class Collection(QueryableType):
             image.download_metadata(path)
 
     @requires_fields("file_locker_files")
-    def download_associated_files(self, path):
+    def download_associated_files(self, path, no_meter=False):
         """Downloads associated files (from file locker) to
         ``associated_files/``."""
         path = os.path.join(path, "associated_files")
         os.makedirs(path, exist_ok=True)
         assets = [(path, file.name, file.url) for file in self.file_locker_files]
-        download_files(assets)
+        download_files(assets, no_meter=no_meter)
 
-    def download_media(self, path):
+    def download_media(self, path, no_meter=False):
         """Downloads videos and images."""
-        self.download_videos(path)
-        self.download_images(path)
+        self.download_videos(path, no_meter=no_meter)
+        self.download_images(path, no_meter=no_meter)
 
-    def download_videos(self, path):
+    def download_videos(self, path, no_meter=False):
         """Downloads videos to ``videos/``."""
         path = os.path.join(path, "videos")
         os.makedirs(path, exist_ok=True)
@@ -276,9 +276,9 @@ class Collection(QueryableType):
         fields.include_field("filename", "url")
         videos = self.get_videos(fields=fields)
         assets = [(path, video.filename, video.url) for video in videos]
-        download_files(assets)
+        download_files(assets, no_meter=no_meter)
 
-    def download_images(self, path):
+    def download_images(self, path, no_meter=False):
         """Downloads images to ``images/``."""
         path = os.path.join(path, "images")
         os.makedirs(path, exist_ok=True)
@@ -286,9 +286,9 @@ class Collection(QueryableType):
         fields.include_field("filename", "url")
         images = self.get_images(fields=fields)
         assets = [(path, image.filename, image.url) for image in images]
-        download_files(assets)
+        download_files(assets, no_meter=no_meter)
 
-    def download_datasets(self, path):
+    def download_datasets(self, path, no_meter=False):
         """Clones and pulls all datasets in the collection."""
         fields = FieldsRequest()
         fields.include_field("name", "repository.master")
@@ -296,4 +296,4 @@ class Collection(QueryableType):
         for dataset in datasets:
             path = os.path.join(path, dataset.name)
             lds = LocalDataset.clone(dataset, clone_path=path)
-            lds.download()
+            lds.download(no_meter=no_meter)

--- a/FLIR/conservator/wrappers/media.py
+++ b/FLIR/conservator/wrappers/media.py
@@ -26,6 +26,6 @@ class MediaType(QueryableType):
             json.dump(json_data, file, indent=4, separators=(",", ": "))
 
     @requires_fields("url", "filename")
-    def download(self, path):
+    def download(self, path, no_meter=False):
         """Download video to ``path``."""
-        download_file(path, self.filename, self.url)
+        download_file(path, self.filename, self.url, no_meter=no_meter)


### PR DESCRIPTION
Add a new argument "no_meter" to download_file() and download_files() in
util.py and to methods that call them -- LocalDataset#download(), the
various Collection download methods, and MediaType#download() for Video
and Image downloads.

Skip Frame.download(), since it appears to be broken (Frame graphql objects
do not have url or filename fields).