### PR TITLE
Fix that excluded leafs included their parents through get_attr_by_path

### DIFF
--- a/FLIR/conservator/fields_request.py
+++ b/FLIR/conservator/fields_request.py
@@ -128,10 +128,10 @@ class FieldsRequest:
         # start by adding all requested fields
         all_selectors = []
         for path, value in self.paths.items():
-            field = self.get_attr_by_path(path, query_selector)
             if value is False or value is None:
                 # excluded field
                 continue
+            field = self.get_attr_by_path(path, query_selector)
             all_selectors.append((path, field))
             if value is True:
                 field()
@@ -153,7 +153,7 @@ class FieldsRequest:
                 leaf_selectors.append(selector)
 
         # if no fields are selected, select defaults on query
-        if len(self.paths) == 0:
+        if len(leaf_selectors) == 0:
             leaf_selectors.append(query_selector)
 
         # add default fields to all leafs:


### PR DESCRIPTION
We no longer call `get_attr_by_path` for excluded fields (which had the effect of including parents to reach the passed field and may add extra fields than should be included).

Also, check length of leafs, not requested paths.