### PR TITLE
Add documentation for collection upload

### DIFF
--- a/docs/usage/cli_quickstart.rst
+++ b/docs/usage/cli_quickstart.rst
@@ -142,12 +142,17 @@ uploading media, as it has safeguards to retry failures, perform uploads in para
 and output status clearly. To recursively create remote collections and uploads media
 from a local path::
 
-    $ conservator collections upload /remote/collection/path /local/path/to/upload --recursive
+    $ conservator collections upload --recursive /remote/collection/path /local/path/to/upload
 
 This command has options to filter the uploaded files and behavior. For all options,
 run::
 
     $ conservator collections upload --help
+
+.. note::
+    Currently, this command only accepts a directory path and can't upload a single file
+    path. You would need to create a directory containing only the single file, or use
+    an individual media upload command as explained below.
 
 Alternatively, individual Images and videos can be uploaded with the `upload` command::
 


### PR DESCRIPTION
@SJLC should I remove the docs for individual media upload? Does `collections upload` support uploading a single file?

