### PR TITLE
Fix cvc status command

### DIFF
--- a/FLIR/conservator/cli/cvc.py
+++ b/FLIR/conservator/cli/cvc.py
@@ -147,7 +147,7 @@ def status(local_dataset):
         return
 
     for image_path in images:
-        click.echo("Staged:", image_path)
+        click.echo(f"Staged: {image_path}")
     click.echo("Use 'cvc upload' to upload these images and add them to index.json")
 
 


### PR DESCRIPTION
click.echo() was throwing an exception because it took the second
argument as a file to write to, rather than a second thing to be
printed. Format both pieces into a single message argument.