### PR TITLE
Enforce chmod(600) on config files

### DIFF
--- a/FLIR/conservator/config.py
+++ b/FLIR/conservator/config.py
@@ -72,13 +72,15 @@ class Config:
 
         This file can be loaded using :func:`Config.from_file`.
 
-        .. note:: For security, this file's mode will be set to ``0600``.
+        .. note:: For security, this file's mode will be set to ``600``.
 
         :param path: The file path to save to.
         """
         with open(path, "w") as f:
             json.dump(self.to_dict(), f)
-        os.chmod(path, 0o600)
+        if os.stat(path).st_mode & 0o777 != 0o600:
+            logger.warning("Changing config file mode to 600.")
+            os.chmod(path, 0o600)
 
     def to_dict(self):
         return {
@@ -102,14 +104,16 @@ class Config:
         """
         Creates a :class:`Config` object from a JSON config file.
 
-        .. note:: For security, this file's mode will be set to ``0600``.
+        .. note:: For security, this file's mode will be set to ``600``.
 
         :param path: The path to the JSON config file.
         """
         try:
             with open(path, "r") as config:
                 data = json.load(config)
-            os.chmod(path, 0o600)
+            if os.stat(path).st_mode & 0o777 != 0o600:
+                logger.warning("Changing config file mode to 0600.")
+                os.chmod(path, 0o600)
             return Config.from_dict(data)
         except FileNotFoundError:
             return None


### PR DESCRIPTION
Closes #154 

Tested: Successfully updates existing config file mode to `600` once accessed and sets to `600` on new config