### PR TITLE
Add 'isRemoved' to index.json validation schema

### DIFF
--- a/FLIR/conservator/index_schema.json
+++ b/FLIR/conservator/index_schema.json
@@ -199,6 +199,7 @@
           "type": "array",
           "items": {"$ref": "#/components/frame"}
         },
+        "isRemoved": {"type": "boolean"},
         "owner": {"$ref": "#/definitions/email"},
         "custom": {"$ref": "#/definitions/custom"}
       },


### PR DESCRIPTION
The 'isRemoved' field is not meant for users to modify, but that field can get
populated in video entries inside the index.json coming from Conservator under
certain conditions (namely, that a video or image was added to a dataset
then deleted, so the dataset still refers to that media as source for its frame).

Go ahead and allow 'isRemoved' as a valid member of a video, since the user
should be able to commit their own legitimate changes to index.json without
having to strip out a field that Conservator put there in the first place.