### PR TITLE
Upload resume

### DIFF
--- a/FLIR/conservator/cli/managers.py
+++ b/FLIR/conservator/cli/managers.py
@@ -166,6 +166,11 @@ def get_manager_command(type_manager, sgqlc_type, name):
             help="Include child directories recursively, creating collections as needed",
         )
         @click.option(
+            "--resume-media",
+            is_flag=True,
+            help="Check if media files were previously uploaded, skip if so",
+        )
+        @click.option(
             "-n",
             "--max-retries",
             type=int,
@@ -180,6 +185,7 @@ def get_manager_command(type_manager, sgqlc_type, name):
             media,
             recursive,
             create_collection,
+            resume_media,
             max_retries,
         ):
             manager = get_instance()
@@ -196,6 +202,7 @@ def get_manager_command(type_manager, sgqlc_type, name):
                 associated_files,
                 media,
                 recursive,
+                resume_media,
                 max_retries,
             )
 

--- a/FLIR/conservator/conservator.py
+++ b/FLIR/conservator/conservator.py
@@ -1,7 +1,4 @@
-import functools
 import logging
-import multiprocessing
-import os
 import random
 import re
 import time
@@ -16,9 +13,7 @@ from FLIR.conservator.managers import (
     VideoManager,
     ImageManager,
 )
-from FLIR.conservator.util import base_convert, upload_file
-from FLIR.conservator.wrappers.media import MediaType, MediaUploadRequest
-from FLIR.conservator.wrappers.queryable import InvalidIdException
+from FLIR.conservator.util import base_convert
 
 logger = logging.getLogger(__name__)
 
@@ -92,44 +87,6 @@ class Conservator(ConservatorConnection):
         """
         return Conservator(Config.default(save=save))
 
-    def upload(self, file_path, collection=None, remote_name=None):
-        """
-        Upload a new media object from a local `file_path`, with the specified
-        `remote_name`. It is added to `collection` if given, otherwise it is
-        added to no collection (orphan).
-
-        Conservator Images have separate queries than Videos, but they do not get
-        their own mutations, e.g. they are treated as "Videos" in the upload process.
-        In fact, an uploaded media file is treated by Conservator server as a video
-        until file processing has finished; if it turned out to be an image type
-        (e.g. jpeg) then it will disappear from Videos and appear under Images.
-
-        Returns the ID of the created media object. Note, that it may be a Video ID
-        or an Image ID.
-
-        :param file_path: The local file path to upload.
-        :param collection: If specified, the Collection object, or `str` Collection ID to
-            upload the media to. If not specified, the media is not uploaded to any
-            specific collection (orphan).
-        :param remote_name: If given, the remote name of the media. Otherwise, the local file
-            name is used.
-        """
-        file_path = os.path.expanduser(file_path)
-        assert os.path.isfile(file_path)
-        if remote_name is None:
-            remote_name = os.path.split(file_path)[-1]
-
-        if isinstance(collection, str):
-            collection_id = collection
-        else:
-            collection_id = collection.id
-
-        upload_request = MediaUploadRequest(
-            file_path=file_path, collection_id=collection_id, remote_name=remote_name
-        )
-        result = MediaType.upload(self, upload_request)
-        return result.media_id
-
     def get_media_instance_from_id(self, media_id, fields=None):
         """
         Returns a Video or Image object from an ID. These types are checked in
@@ -147,136 +104,6 @@ class Conservator(ConservatorConnection):
             return media
 
         raise UnknownMediaIdException(f"The type of ID '{media_id}' could not be found")
-
-    def is_uploaded_media_id_processed(self, media_id):
-        """
-        Return `True` if an ID returned by :meth:`~MediaTypeManager.upload` has
-        been processed, and `False` otherwise.
-
-        When media is uploaded, it begins processing as a video. It may turn into
-        an image, requiring different queries. This method can be used to verify
-        that an ID is done processing, and its type won't change in the future.
-        """
-        try:
-            media = self.get_media_instance_from_id(media_id)
-            media.populate("state")
-            return media.state == "completed"
-        except InvalidIdException:
-            return False
-
-    def _wait_for_single_processing(self, media_id, check_frequency_seconds):
-        while not self.is_uploaded_media_id_processed(media_id):
-            logger.debug(f"Media with id='{media_id}' is not processed yet")
-            time.sleep(check_frequency_seconds)
-        logger.info(f"Media with id='{media_id}' is processed!")
-        return True
-
-    def wait_for_processing(
-        self, media_ids, timeout_seconds=600, check_frequency_seconds=5
-    ):
-        """
-        Wait for an id, or list of ids, to complete processing.
-
-        :param media_ids: A single `str` media ID, or a list of media ID to test.
-        :param timeout_seconds: A maximum amount of time to wait.
-        :param check_frequency_seconds: How long to wait between checks.
-        """
-        if isinstance(media_ids, str):
-            media_ids = [media_ids]
-
-        pool = multiprocessing.Pool()
-        args = [(media_id, check_frequency_seconds) for media_id in media_ids]
-        results = pool.starmap_async(self._wait_for_single_processing, args)
-        try:
-            processed = results.get(timeout=timeout_seconds)
-            logger.debug(f"All media process checks returned, checking success")
-            assert all(processed)
-        except multiprocessing.TimeoutError:
-            logger.debug(f"Media processing check timed out!")
-            raise ProcessingTimeoutError()
-
-    def _upload_many(self, upload_requests, process_count=None, max_retries=-1):
-        """
-        Upload many files in parallel. Returns the ids for media that were
-        successfully uploaded (failed uploads will be logged as warning).
-
-        :param upload_requests: A list of :class:`MediaUploadRequest` objects
-            that will be passed to :meth:`~MediaTypeManager.upload`.
-        :param process_count: Number of concurrent upload processes. Passing `None`
-            will use `os.cpu_count()`.
-        :param max_retries: maximum number of times upload will be attempted again
-            for a file, if the initial attempt to upload that file fails. Value less
-            than zero is interpreted as infinite retries.
-        """
-        pool = multiprocessing.Pool(process_count)
-        upload_func = functools.partial(
-            MediaType.upload, self
-        )  # pass in conservator instance
-        pending_uploads = list(upload_requests)
-        complete_uploads = []
-
-        tries = 0
-        while pending_uploads:
-            if max_retries >= 0 and tries > max_retries:
-                logger.info("Ran out of retries, giving up")
-                break
-
-            logger.info("Upload attempt #%d", tries)
-            results = pool.map(upload_func, pending_uploads)
-            for upload in results:
-                if upload.complete:
-                    complete_uploads.append(upload)
-                    pending_uploads.remove(upload)
-                else:
-                    logger.warning(
-                        "Failed attempt to upload %s: %s",
-                        upload.file_path,
-                        upload.error_message,
-                    )
-            tries += 1
-
-        if pending_uploads:
-            file_list = [upload.file_path for upload in pending_uploads]
-            logger.warning("Following files failed to upload: %s", file_list)
-
-        media_ids = [upload.media_id for upload in complete_uploads]
-        return media_ids
-
-    def upload_many_to_collection(
-        self, file_paths, collection, process_count=None, max_retries=-1
-    ):
-        """
-        Upload many files in parallel. Returns a list of the uploaded media IDs.
-
-        :param file_paths: A list of `str` file paths to upload to `collection`. Alternatively,
-            a list of `(str, str)` tuples holding pairs of `local_path`, `remote_name`. If `remote_name`
-            is `None`, the local filename will be used.
-        :param collection: The collection to upload media files to.
-        :param process_count: Number of concurrent upload processes. Passing `None`
-            will use `os.cpu_count()`.
-        """
-        if len(file_paths) == 0:
-            return
-
-        if isinstance(file_paths[0], str):
-            file_paths = [(file_path, None) for file_path in file_paths]
-
-        upload_requests = [
-            MediaUploadRequest(file_path[0], collection.id, file_path[1])
-            for file_path in file_paths
-        ]
-        return self._upload_many(
-            upload_requests, process_count=process_count, max_retries=max_retries
-        )
-
-
-class ProcessingTimeoutError(TimeoutError):
-    """
-    Raised when the amount of time spent waiting for media to process exceeds
-    the requested timeout.
-    """
-
-    pass
 
 
 class UnknownMediaIdException(Exception):

--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -11,7 +11,7 @@ import time
 
 import jsonschema
 from PIL import Image
-from FLIR.conservator.util import download_files
+from FLIR.conservator.util import download_files, md5sum_file
 
 
 logger = logging.getLogger(__name__)
@@ -292,7 +292,7 @@ class LocalDataset:
             "width": image.width,
             "height": image.height,
             "fileSize": os.path.getsize(path),
-            "md5": hashlib.md5(open(path, "rb").read()).hexdigest(),
+            "md5": md5sum_file(path, "rb"),
         }
         return info
 

--- a/FLIR/conservator/managers/__init__.py
+++ b/FLIR/conservator/managers/__init__.py
@@ -7,10 +7,8 @@ import logging
 import os
 
 from FLIR.conservator.managers.media import MediaTypeManager
-from FLIR.conservator.managers.searchable import (
-    SearchableTypeManager,
-    AmbiguousIdentifierException,
-)
+from FLIR.conservator.managers.searchable import SearchableTypeManager
+from FLIR.conservator.managers.type_manager import AmbiguousIdentifierException
 from FLIR.conservator.wrappers import (
     Collection,
     Dataset,

--- a/FLIR/conservator/managers/__init__.py
+++ b/FLIR/conservator/managers/__init__.py
@@ -122,7 +122,8 @@ class CollectionManager(SearchableTypeManager):
 
         if media:
             logger.info("Uploading media to collection %s", collection.path)
-            self._conservator.upload_many_to_collection(
+            media_manager = MediaTypeManager(self._conservator)
+            media_manager.upload_many_to_collection(
                 media_paths, collection, max_retries=max_retries
             )
 
@@ -169,6 +170,7 @@ class CollectionManager(SearchableTypeManager):
                     associated_files,
                     media,
                     recursive,
+                    max_retries,
                 )
 
 

--- a/FLIR/conservator/managers/__init__.py
+++ b/FLIR/conservator/managers/__init__.py
@@ -7,7 +7,10 @@ import logging
 import os
 
 from FLIR.conservator.managers.media import MediaTypeManager
-from FLIR.conservator.managers.searchable import SearchableTypeManager, AmbiguousIdentifierException
+from FLIR.conservator.managers.searchable import (
+    SearchableTypeManager,
+    AmbiguousIdentifierException,
+)
 from FLIR.conservator.wrappers import (
     Collection,
     Dataset,
@@ -91,6 +94,7 @@ class CollectionManager(SearchableTypeManager):
         associated_files,
         media,
         recursive,
+        resume_media,
         max_retries,
     ):
         """
@@ -119,7 +123,7 @@ class CollectionManager(SearchableTypeManager):
             logger.info("Uploading media to collection %s", collection.path)
             media_manager = MediaTypeManager(self._conservator)
             media_manager.upload_many_to_collection(
-                media_paths, collection, max_retries=max_retries
+                media_paths, collection, resume=resume_media, max_retries=max_retries
             )
 
         if video_metadata:
@@ -165,6 +169,7 @@ class CollectionManager(SearchableTypeManager):
                     associated_files,
                     media,
                     recursive,
+                    resume_media,
                     max_retries,
                 )
 

--- a/FLIR/conservator/managers/__init__.py
+++ b/FLIR/conservator/managers/__init__.py
@@ -7,7 +7,7 @@ import logging
 import os
 
 from FLIR.conservator.managers.media import MediaTypeManager
-from FLIR.conservator.managers.searchable import SearchableTypeManager
+from FLIR.conservator.managers.searchable import SearchableTypeManager, AmbiguousIdentifierException
 from FLIR.conservator.wrappers import (
     Collection,
     Dataset,
@@ -19,11 +19,6 @@ from FLIR.conservator.wrappers import (
 
 
 logger = logging.getLogger(__name__)
-
-
-class AmbiguousIdentifierException(Exception):
-    def __init__(self, identifier):
-        super().__init__(f"Multiple items found for '{identifier}', use ID")
 
 
 class CollectionManager(SearchableTypeManager):

--- a/FLIR/conservator/managers/media.py
+++ b/FLIR/conservator/managers/media.py
@@ -6,7 +6,7 @@ import time
 
 from FLIR.conservator.fields_request import FieldsRequest
 from FLIR.conservator.util import upload_file
-from FLIR.conservator.managers.searchable import AmbiguousIdentifierException
+from FLIR.conservator.managers.type_manager import AmbiguousIdentifierException
 from FLIR.conservator.wrappers.media import MediaType, MediaUploadRequest, MediaCompare
 from FLIR.conservator.wrappers.queryable import InvalidIdException
 

--- a/FLIR/conservator/managers/media.py
+++ b/FLIR/conservator/managers/media.py
@@ -1,3 +1,184 @@
+import functools
+import logging
+import multiprocessing
+import os
+import time
+
+from FLIR.conservator.util import upload_file
+from FLIR.conservator.wrappers.media import MediaType, MediaUploadRequest
+from FLIR.conservator.wrappers.queryable import InvalidIdException
+
+logger = logging.getLogger(__name__)
+
+
+class ProcessingTimeoutError(TimeoutError):
+    """
+    Raised when the amount of time spent waiting for media to process exceeds
+    the requested timeout.
+    """
+
+    pass
+
+
 class MediaTypeManager:
     def __init__(self, conservator):
         self._conservator = conservator
+
+    def upload(self, file_path, collection=None, remote_name=None):
+        """
+        Upload a new media object from a local `file_path`, with the specified
+        `remote_name`. It is added to `collection` if given, otherwise it is
+        added to no collection (orphan).
+
+        Conservator Images have separate queries than Videos, but they do not get
+        their own mutations, e.g. they are treated as "Videos" in the upload process.
+        In fact, an uploaded media file is treated by Conservator server as a video
+        until file processing has finished; if it turned out to be an image type
+        (e.g. jpeg) then it will disappear from Videos and appear under Images.
+
+        Returns the ID of the created media object. Note, that it may be a Video ID
+        or an Image ID.
+
+        :param file_path: The local file path to upload.
+        :param collection: If specified, the Collection object, or `str` Collection ID to
+            upload the media to. If not specified, the media is not uploaded to any
+            specific collection (orphan).
+        :param remote_name: If given, the remote name of the media. Otherwise, the local file
+            name is used.
+        """
+        file_path = os.path.expanduser(file_path)
+        assert os.path.isfile(file_path)
+        if remote_name is None:
+            remote_name = os.path.split(file_path)[-1]
+
+        if isinstance(collection, str):
+            collection_id = collection
+        else:
+            collection_id = collection.id
+
+        upload_request = MediaUploadRequest(
+            file_path=file_path, collection_id=collection_id, remote_name=remote_name
+        )
+        result = MediaType.upload(self, upload_request)
+        return result.media_id
+
+    def is_uploaded_media_id_processed(self, media_id):
+        """
+        Return `True` if an ID returned by :meth:`~MediaTypeManager.upload` has
+        been processed, and `False` otherwise.
+
+        When media is uploaded, it begins processing as a video. It may turn into
+        an image, requiring different queries. This method can be used to verify
+        that an ID is done processing, and its type won't change in the future.
+        """
+        try:
+            media = self._conservator.get_media_instance_from_id(media_id)
+            media.populate("state")
+            return media.state == "completed"
+        except InvalidIdException:
+            return False
+
+    def _wait_for_single_processing(self, media_id, check_frequency_seconds):
+        while not self.is_uploaded_media_id_processed(media_id):
+            logger.debug(f"Media with id='{media_id}' is not processed yet")
+            time.sleep(check_frequency_seconds)
+        logger.info(f"Media with id='{media_id}' is processed!")
+        return True
+
+    def wait_for_processing(
+        self, media_ids, timeout_seconds=600, check_frequency_seconds=5
+    ):
+        """
+        Wait for an id, or list of ids, to complete processing.
+
+        :param media_ids: A single `str` media ID, or a list of media ID to test.
+        :param timeout_seconds: A maximum amount of time to wait.
+        :param check_frequency_seconds: How long to wait between checks.
+        """
+        if isinstance(media_ids, str):
+            media_ids = [media_ids]
+
+        pool = multiprocessing.Pool()
+        args = [(media_id, check_frequency_seconds) for media_id in media_ids]
+        results = pool.starmap_async(self._wait_for_single_processing, args)
+        try:
+            processed = results.get(timeout=timeout_seconds)
+            logger.debug(f"All media process checks returned, checking success")
+            assert all(processed)
+        except multiprocessing.TimeoutError:
+            logger.debug(f"Media processing check timed out!")
+            raise ProcessingTimeoutError()
+
+    def _upload_many(self, upload_requests, process_count=None, max_retries=-1):
+        """
+        Upload many files in parallel. Returns the ids for media that were
+        successfully uploaded (failed uploads will be logged as warning).
+
+        :param upload_requests: A list of :class:`MediaUploadRequest` objects
+            that will be passed to :meth:`~MediaTypeManager.upload`.
+        :param process_count: Number of concurrent upload processes. Passing `None`
+            will use `os.cpu_count()`.
+        :param max_retries: maximum number of times upload will be attempted again
+            for a file, if the initial attempt to upload that file fails. Value less
+            than zero is interpreted as infinite retries.
+        """
+        pool = multiprocessing.Pool(process_count)
+        upload_func = functools.partial(
+            MediaType.upload, self._conservator
+        )  # pass in conservator instance
+        pending_uploads = list(upload_requests)
+        complete_uploads = []
+
+        tries = 0
+        while pending_uploads:
+            if max_retries >= 0 and tries > max_retries:
+                logger.info("Ran out of retries, giving up")
+                break
+
+            logger.info("Upload attempt #%d", tries)
+            results = pool.map(upload_func, pending_uploads)
+            for upload in results:
+                if upload.complete:
+                    complete_uploads.append(upload)
+                    pending_uploads.remove(upload)
+                else:
+                    logger.warning(
+                        "Failed attempt to upload %s: %s",
+                        upload.file_path,
+                        upload.error_message,
+                    )
+            tries += 1
+
+        if pending_uploads:
+            file_list = [upload.file_path for upload in pending_uploads]
+            logger.warning("Following files failed to upload: %s", file_list)
+
+        media_ids = [upload.media_id for upload in complete_uploads]
+        return media_ids
+
+    def upload_many_to_collection(
+        self, file_paths, collection, process_count=None, max_retries=-1
+    ):
+        """
+        Upload many files in parallel. Returns a list of the uploaded media IDs.
+
+        :param file_paths: A list of `str` file paths to upload to `collection`. Alternatively,
+            a list of `(str, str)` tuples holding pairs of `local_path`, `remote_name`. If `remote_name`
+            is `None`, the local filename will be used.
+        :param collection: The collection to upload media files to.
+        :param process_count: Number of concurrent upload processes. Passing `None`
+            will use `os.cpu_count()`.
+        """
+        if len(file_paths) == 0:
+            return
+
+        if isinstance(file_paths[0], str):
+            file_paths = [(file_path, None) for file_path in file_paths]
+
+        upload_requests = [
+            MediaUploadRequest(file_path[0], collection.id, file_path[1])
+            for file_path in file_paths
+        ]
+        return self._upload_many(
+            upload_requests, process_count=process_count, max_retries=max_retries
+        )

--- a/FLIR/conservator/managers/searchable.py
+++ b/FLIR/conservator/managers/searchable.py
@@ -2,6 +2,11 @@ from FLIR.conservator.managers.type_manager import TypeManager
 from FLIR.conservator.paginated_query import PaginatedQuery
 
 
+class AmbiguousIdentifierException(Exception):
+    def __init__(self, identifier):
+        super().__init__(f"Multiple items found for '{identifier}', use ID")
+
+
 class SearchableTypeManager(TypeManager):
     """
     Adds the ability to search using Conservator's Advanced Search.

--- a/FLIR/conservator/managers/searchable.py
+++ b/FLIR/conservator/managers/searchable.py
@@ -2,11 +2,6 @@ from FLIR.conservator.managers.type_manager import TypeManager
 from FLIR.conservator.paginated_query import PaginatedQuery
 
 
-class AmbiguousIdentifierException(Exception):
-    def __init__(self, identifier):
-        super().__init__(f"Multiple items found for '{identifier}', use ID")
-
-
 class SearchableTypeManager(TypeManager):
     """
     Adds the ability to search using Conservator's Advanced Search.

--- a/FLIR/conservator/managers/type_manager.py
+++ b/FLIR/conservator/managers/type_manager.py
@@ -1,6 +1,11 @@
 from FLIR.conservator.wrappers.queryable import InvalidIdException
 
 
+class AmbiguousIdentifierException(Exception):
+    def __init__(self, identifier):
+        super().__init__(f"Multiple items found for '{identifier}', use ID")
+
+
 class TypeManager:
     """
     Base Manger class.

--- a/FLIR/conservator/util.py
+++ b/FLIR/conservator/util.py
@@ -78,14 +78,12 @@ def download_file(path, name, url, silent=False, no_meter=False):
     return True
 
 
-def md5sum_file(path, block_size=1024 * 1024):
-    hasher = hashlib.md5()
-    with open(path, "rb") as fp:
-        block = fp.read(block_size)
-        while block:
-            hasher.update(block)
-            block = fp.read(block_size)
-    return hasher.hexdigest()
+def download_files(files, process_count=None, no_meter=False):
+    # files = (path, name, url)
+    pool = multiprocessing.Pool(process_count)  # defaults to CPU count
+    args = [(*file, True, no_meter) for i, file in enumerate(files)]
+    results = pool.starmap(download_file, args)
+    return results
 
 
 def upload_file(path, url):
@@ -98,12 +96,14 @@ def upload_file(path, url):
     return response
 
 
-def download_files(files, process_count=None, no_meter=False):
-    # files = (path, name, url)
-    pool = multiprocessing.Pool(process_count)  # defaults to CPU count
-    args = [(*file, True, no_meter) for i, file in enumerate(files)]
-    results = pool.starmap(download_file, args)
-    return results
+def md5sum_file(path, block_size=1024 * 1024):
+    hasher = hashlib.md5()
+    with open(path, "rb") as fp:
+        block = fp.read(block_size)
+        while block:
+            hasher.update(block)
+            block = fp.read(block_size)
+    return hasher.hexdigest()
 
 
 def base_convert(b, n):

--- a/FLIR/conservator/util.py
+++ b/FLIR/conservator/util.py
@@ -1,7 +1,7 @@
+import hashlib
 import multiprocessing
 import os
 import logging
-
 import requests
 import tqdm
 
@@ -76,6 +76,16 @@ def download_file(path, name, url, silent=False, no_meter=False):
             fd.write(chunk)
     progress.close()
     return True
+
+
+def md5sum_file(path, block_size=1024 * 1024):
+    hasher = hashlib.md5()
+    with open(path, "rb") as fp:
+        block = fp.read(block_size)
+        while block:
+            hasher.update(block)
+            block = fp.read(block_size)
+    return hasher.hexdigest()
 
 
 def upload_file(path, url):

--- a/FLIR/conservator/wrappers/collection.py
+++ b/FLIR/conservator/wrappers/collection.py
@@ -164,7 +164,12 @@ class Collection(QueryableType, FileLockerType):
     def get_images(self, fields=None, search_text=""):
         """Returns a query for all images in this collection."""
         images = PaginatedQuery(
-            self._conservator, Image, Query.images, fields=fields, search_text=search_text, collection_id=self.id
+            self._conservator,
+            Image,
+            Query.images,
+            fields=fields,
+            search_text=search_text,
+            collection_id=self.id,
         )
         return images
 
@@ -176,7 +181,12 @@ class Collection(QueryableType, FileLockerType):
     def get_videos(self, fields=None, search_text=""):
         """Returns a query for all videos in this collection."""
         videos = PaginatedQuery(
-            self._conservator, Video, Query.videos, fields=fields, search_text=search_text, collection_id=self.id
+            self._conservator,
+            Video,
+            Query.videos,
+            fields=fields,
+            search_text=search_text,
+            collection_id=self.id,
         )
         return videos
 
@@ -218,7 +228,11 @@ class Collection(QueryableType, FileLockerType):
         """
         metadata = MetadataInput(mode="remove", collections=[self.id])
         self._conservator.query(
-            Mutation.update_video, operation_base=Mutation, id=media_id, metadata=metadata, fields="id"
+            Mutation.update_video,
+            operation_base=Mutation,
+            id=media_id,
+            metadata=metadata,
+            fields="id",
         )
 
     def delete(self):

--- a/FLIR/conservator/wrappers/collection.py
+++ b/FLIR/conservator/wrappers/collection.py
@@ -9,6 +9,7 @@ from FLIR.conservator.generated.schema import (
     Mutation,
     CreateCollectionInput,
     DeleteCollectionInput,
+    MetadataInput,
 )
 from FLIR.conservator.local_dataset import LocalDataset
 from FLIR.conservator.paginated_query import PaginatedQuery
@@ -210,6 +211,15 @@ class Collection(QueryableType, FileLockerType):
             collection_id=self.id,
         )
         return datasets
+
+    def remove_media(self, media_id):
+        """
+        Remove given media from this collection.
+        """
+        metadata = MetadataInput(mode="remove", collections=[self.id])
+        self._conservator.query(
+            Mutation.update_video, operation_base=Mutation, id=media_id, metadata=metadata, fields="id"
+        )
 
     def delete(self):
         """

--- a/FLIR/conservator/wrappers/collection.py
+++ b/FLIR/conservator/wrappers/collection.py
@@ -160,52 +160,53 @@ class Collection(QueryableType, FileLockerType):
             yield collection
             collections.extend(collection.children)
 
-    def get_images(self, fields=None):
+    def get_images(self, fields=None, search_text=""):
         """Returns a query for all images in this collection."""
         images = PaginatedQuery(
-            self._conservator, Image, Query.images, fields=fields, collection_id=self.id
+            self._conservator, Image, Query.images, fields=fields, search_text=search_text, collection_id=self.id
         )
         return images
 
-    def recursively_get_images(self, fields=None):
+    def recursively_get_images(self, fields=None, search_text=""):
         """Yields all images in this and child collections recursively"""
         for collection in self.recursively_get_children(include_self=True, fields="id"):
-            yield from collection.get_images(fields)
+            yield from collection.get_images(fields, search_text)
 
-    def get_videos(self, fields=None):
+    def get_videos(self, fields=None, search_text=""):
         """Returns a query for all videos in this collection."""
         videos = PaginatedQuery(
-            self._conservator, Video, Query.videos, fields=fields, collection_id=self.id
+            self._conservator, Video, Query.videos, fields=fields, search_text=search_text, collection_id=self.id
         )
         return videos
 
-    def recursively_get_videos(self, fields=None):
+    def recursively_get_videos(self, fields=None, search_text=""):
         """Yields all videos in this and child collections recursively"""
         for collection in self.recursively_get_children(include_self=True, fields="id"):
-            yield from collection.get_videos(fields)
+            yield from collection.get_videos(fields, search_text)
 
-    def get_media(self, fields=None):
+    def get_media(self, fields=None, search_text=""):
         """
         Yields all videos, then images in this collection.
 
         :param fields: The `fields` to include in the media. All
             fields must exist on both Image and Video types.
         """
-        yield from self.get_videos(fields=fields)
-        yield from self.get_images(fields=fields)
+        yield from self.get_videos(fields=fields, search_text=search_text)
+        yield from self.get_images(fields=fields, search_text=search_text)
 
-    def recursively_get_media(self, fields=None):
+    def recursively_get_media(self, fields=None, search_text=""):
         """Yields all videos and images in this and child collections recursively"""
         for collection in self.recursively_get_children(include_self=True, fields="id"):
-            yield from collection.get_media(fields)
+            yield from collection.get_media(fields, search_text)
 
-    def get_datasets(self, fields=None):
+    def get_datasets(self, fields=None, search_text=""):
         """Returns a query for all datasets in this collection."""
         datasets = PaginatedQuery(
             self._conservator,
             Dataset,
             Query.datasets,
             fields=fields,
+            search_text=search_text,
             collection_id=self.id,
         )
         return datasets

--- a/FLIR/conservator/wrappers/image.py
+++ b/FLIR/conservator/wrappers/image.py
@@ -1,8 +1,25 @@
 from FLIR.conservator.generated import schema
-from FLIR.conservator.wrappers.media import MediaType
+from FLIR.conservator.util import md5sum_file
+from FLIR.conservator.wrappers.media import MediaType, MediaCompare
+from FLIR.conservator.wrappers.type_proxy import requires_fields
 
 
 class Image(MediaType):
     underlying_type = schema.Image
     by_id_query = schema.Query.image
     search_query = schema.Query.images
+
+    @requires_fields("image_md5")
+    def compare(self, local_path):
+        """
+        Use md5 checksums to compare image contents to local file
+
+        Returns result as MediaCompare object
+
+        :param local_path: Path to local copy of file for comparison with remote.
+        """
+        result = MediaCompare.MISMATCH
+        local_md5 = md5sum_file(local_path)
+        if local_md5 == self.image_md5:
+            result = MediaCompare.MATCH
+        return result

--- a/FLIR/conservator/wrappers/image.py
+++ b/FLIR/conservator/wrappers/image.py
@@ -1,6 +1,5 @@
 from FLIR.conservator.generated import schema
-from FLIR.conservator.util import md5sum_file
-from FLIR.conservator.wrappers.media import MediaType, MediaCompare
+from FLIR.conservator.wrappers.media import MediaType
 from FLIR.conservator.wrappers.type_proxy import requires_fields
 
 
@@ -18,8 +17,4 @@ class Image(MediaType):
 
         :param local_path: Path to local copy of file for comparison with remote.
         """
-        result = MediaCompare.MISMATCH
-        local_md5 = md5sum_file(local_path)
-        if local_md5 == self.image_md5:
-            result = MediaCompare.MATCH
-        return result
+        return self.verify_md5(local_path, self.image_md5)

--- a/FLIR/conservator/wrappers/media.py
+++ b/FLIR/conservator/wrappers/media.py
@@ -1,3 +1,4 @@
+import enum
 import os
 import traceback
 from dataclasses import dataclass
@@ -15,6 +16,16 @@ class MediaUploadException(Exception):
     """Raised if an exception occurs during a media upload"""
 
     pass
+
+
+class MediaCompare(enum.Enum):
+    """results of comparing local file and Conservator file"""
+
+    MISMATCH = 0
+    MATCH = 1
+
+    def ok(self):
+        return self.name == "MATCH"
 
 
 @dataclass

--- a/FLIR/conservator/wrappers/media.py
+++ b/FLIR/conservator/wrappers/media.py
@@ -4,8 +4,7 @@ import traceback
 from dataclasses import dataclass
 
 from FLIR.conservator.generated.schema import Mutation
-from FLIR.conservator.util import download_file
-from FLIR.conservator.util import upload_file
+from FLIR.conservator.util import md5sum_file, download_file, upload_file
 from FLIR.conservator.wrappers import QueryableType
 from FLIR.conservator.wrappers.file_locker import FileLockerType
 from FLIR.conservator.wrappers.metadata import MetadataType
@@ -68,6 +67,16 @@ class MediaType(QueryableType, FileLockerType, MetadataType):
     # metadata operations
     metadata_gen_url = Mutation.generate_signed_metadata_upload_url
     metadata_confirm_url = Mutation.mark_annotation_as_uploaded
+
+    def verify_md5(self, local_path, expected_md5):
+        """
+        Helper for Video and Image md5sum comparisons, each of which
+        track md5sum in Conservator but not in the same field
+        """
+        local_md5 = md5sum_file(local_path)
+        if local_md5 == expected_md5:
+            return MediaCompare.MATCH
+        return MediaCompare.MISMATCH
 
     def _trigger_processing(
         self,

--- a/FLIR/conservator/wrappers/video.py
+++ b/FLIR/conservator/wrappers/video.py
@@ -2,14 +2,31 @@ from FLIR.conservator.fields_request import FieldsRequest
 from FLIR.conservator.generated import schema
 from FLIR.conservator.generated.schema import Query, Mutation
 from FLIR.conservator.paginated_query import PaginatedQuery
+from FLIR.conservator.util import md5sum_file
 from FLIR.conservator.wrappers.frame import Frame
-from FLIR.conservator.wrappers.media import MediaType
+from FLIR.conservator.wrappers.media import MediaType, MediaCompare
+from FLIR.conservator.wrappers.type_proxy import requires_fields
 
 
 class Video(MediaType):
     underlying_type = schema.Video
     by_id_query = schema.Query.video
     search_query = schema.Query.videos
+
+    @requires_fields("md5")
+    def compare(self, local_path):
+        """
+        Use md5 checksums to compare video contents to local file
+
+        Returns result as MediaCompare object
+
+        :param local_path: Path to local copy of file for comparison with remote.
+        """
+        result = MediaCompare.MISMATCH
+        local_md5 = md5sum_file(local_path)
+        if local_md5 == self.md5:
+            result = MediaCompare.MATCH
+        return result
 
     def get_annotations(self, fields=None):
         """

--- a/FLIR/conservator/wrappers/video.py
+++ b/FLIR/conservator/wrappers/video.py
@@ -2,9 +2,8 @@ from FLIR.conservator.fields_request import FieldsRequest
 from FLIR.conservator.generated import schema
 from FLIR.conservator.generated.schema import Query, Mutation
 from FLIR.conservator.paginated_query import PaginatedQuery
-from FLIR.conservator.util import md5sum_file
 from FLIR.conservator.wrappers.frame import Frame
-from FLIR.conservator.wrappers.media import MediaType, MediaCompare
+from FLIR.conservator.wrappers.media import MediaType
 from FLIR.conservator.wrappers.type_proxy import requires_fields
 
 
@@ -22,11 +21,7 @@ class Video(MediaType):
 
         :param local_path: Path to local copy of file for comparison with remote.
         """
-        result = MediaCompare.MISMATCH
-        local_md5 = md5sum_file(local_path)
-        if local_md5 == self.md5:
-            result = MediaCompare.MATCH
-        return result
+        return self.verify_md5(local_path, self.md5)
 
     def get_annotations(self, fields=None):
         """

--- a/examples/upload_many_videos.py
+++ b/examples/upload_many_videos.py
@@ -28,13 +28,13 @@ assert collection is not None
 upload_tuples = [(local_path, f"upload_many_test_{i}") for i in range(number_of_copies)]
 
 print("Starting upload")
-media_ids = conservator.upload_many_to_collection(
+media_ids = conservator.videos.upload_many_to_collection(
     upload_tuples, collection=collection, process_count=10
 )
 print("Created these ids:", media_ids)
 
 print("Waiting for processing")
-conservator.wait_for_processing(media_ids)
+conservator.videos.wait_for_processing(media_ids)
 
 # Print out all of the media names
 for media_id in media_ids:


### PR DESCRIPTION
### resume option for collections upload

The new --resume-media option will first check whether a file queued up
to be uploaded has previously been uploaded to Conservator in the 
destination folder (files of the same name but different folders are 
ignored).

* If there is an incomplete upload at the destination path,
  that invalid partial file will be deleted from Conservator
  before new upload attempt
* If there is a complete file at the destination path but it has 
  different md5sum than the local copy, that media file will be
  removed from the destination folder to avoid 2 files of same name
  in folder (but will not be altogether deleted from Conservator)
* If there is a complete file at the destination path that matches
  the md5sum of the local copy, upload of that file can be skipped
