### PR TITLE
conservator_cli plugin for running CLI commands from another app

### DIFF
--- a/FLIR/conservator/configs/download.json
+++ b/FLIR/conservator/configs/download.json
@@ -8,9 +8,8 @@
             "description": "download a test folder from Conservator",
             "task_type": "conservator_cli",
             "task_config": {
-                "cmd_class": "collections",
-                "cmd_name": "download",
-                "args": ["--media", "--recursive", "/SomeTestFolder", "/tmp/dl"],
+                "cmd": "collections",
+                "args": ["download", "--media", "--recursive", "/SomeTestFolder", "/tmp/dl"],
                 "log": "DEBUG"
             }
         }

--- a/FLIR/conservator/configs/download.json
+++ b/FLIR/conservator/configs/download.json
@@ -1,0 +1,18 @@
+{
+    "name": "Folder download example",
+    "description": "Demonstrate downloading a folder from Conservator",
+    "plugin_registry": { "$discover_tasks": "FLIR/*/run_tasks_plugins"},
+    "tasks": [
+        {
+            "name": "download_folder",
+            "description": "download a test folder from Conservator",
+            "task_type": "conservator_cli",
+            "task_config": {
+                "cmd_class": "collections",
+                "cmd_name": "download",
+                "args": ["--media", "--recursive", "/SomeTestFolder", "/tmp/dl"],
+                "log": "DEBUG"
+            }
+        }
+    ]
+}

--- a/FLIR/conservator/configs/upload.json
+++ b/FLIR/conservator/configs/upload.json
@@ -1,0 +1,18 @@
+{
+    "name": "Folder upload example",
+    "description": "Demonstrate uploading a folder to Conservator",
+    "plugin_registry": { "$discover_tasks": "FLIR/*/run_tasks_plugins"},
+    "tasks": [
+        {
+            "name": "upload_folder",
+            "description": "upload a test folder to Conservator",
+            "task_type": "conservator_cli",
+            "task_config": {
+                "cmd_class": "collections",
+                "cmd_name": "upload",
+                "args": ["--media", "--recursive", "--resume-media", "/SomeTestFolder", "/tmp/dl"],
+                "log": "DEBUG"
+            }
+        }
+    ]
+}

--- a/FLIR/conservator/configs/upload.json
+++ b/FLIR/conservator/configs/upload.json
@@ -8,9 +8,8 @@
             "description": "upload a test folder to Conservator",
             "task_type": "conservator_cli",
             "task_config": {
-                "cmd_class": "collections",
-                "cmd_name": "upload",
-                "args": ["--media", "--recursive", "--resume-media", "/SomeTestFolder", "/tmp/dl"],
+                "cmd": "collections",
+                "args": ["upload", "--media", "--recursive", "--resume-media", "/SomeTestFolder", "/tmp/dl"],
                 "log": "DEBUG"
             }
         }

--- a/FLIR/conservator/run_tasks_plugins/conservator_cli.py
+++ b/FLIR/conservator/run_tasks_plugins/conservator_cli.py
@@ -1,0 +1,11 @@
+from FLIR.conservator.cli import main
+
+
+def conservator_cli(cmd_class, cmd_name, args=(), log="INFO", task=None):
+    cli_cmd = [cmd_class, cmd_name] + list(args)
+    result = main(cli_cmd, standalone_mode=False)
+    print("RESULT:", result)
+    return result
+
+
+exports = [conservator_cli]

--- a/FLIR/conservator/run_tasks_plugins/conservator_cli.py
+++ b/FLIR/conservator/run_tasks_plugins/conservator_cli.py
@@ -1,8 +1,9 @@
 from FLIR.conservator.cli import main
 
 
-def conservator_cli(cmd_class, cmd_name, args=(), log="INFO", task=None):
-    cli_cmd = [cmd_class, cmd_name] + list(args)
+def conservator_cli(cmd, args=(), log="INFO", task=None):
+    log_arg = "--log=" + log
+    cli_cmd = [log_arg, cmd] + list(args)
     result = main(cli_cmd, standalone_mode=False)
     print("RESULT:", result)
     return result

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
     url="https://github.com/FLIR/conservator-cli",
     packages=find_namespace_packages(include=["FLIR.*"], exclude=["*.test.*"]),
     package_data={
-        "FLIR.conservator": ["index_schema.json"],
+        "FLIR.conservator": ["index_schema.json", "configs/*.json"],
     },
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
conservator_cli allows directly calling CLI commands from an app instead
of using python subprocess to execute them as a child process. This
method allows CLI commands to return objects that would be further
operated in by the parent app, rather than ugly hacks where the parent
tries to reconstruct an object by parsing stdout from conservator tool
running as a subprocess.

The actual parent app that conservator_cli was tested with lives in
another (non-public) repo, but this includes a couple of example configs
that give the idea of how conservator_cli() would be called from a
parent app (see "task_config" sections).