### PR TITLE
Allow null qaStatus in index.json

### DIFF
--- a/FLIR/conservator/index_schema.json
+++ b/FLIR/conservator/index_schema.json
@@ -160,8 +160,8 @@
         "isEmpty": {"type": "boolean"},
         "isFlagged": {"type": "boolean"},
         "qaStatus": {
-          "type": "string",
-          "enum": ["approved", "changesRequested"]
+          "type":  ["string", "null"],
+          "enum": ["approved", "changesRequested", null]
         },
         "qaStatusNote": {"$ref": "#/definitions/noNull"},
         "md5": {"$ref": "#/definitions/md5hash"},
@@ -215,8 +215,8 @@
         "isEmpty": {"type": "boolean"},
         "isFlagged": {"type": "boolean"},
         "qaStatus": {
-          "type": "string",
-          "enum": ["approved", "changesRequested"]
+          "type": ["string", "null"],
+          "enum": ["approved", "changesRequested", null]
         },
         "qaStatusNote": {"$ref": "#/definitions/noNull"},
         "md5": {"$ref": "#/definitions/md5hash"},


### PR DESCRIPTION
Tested on a local index.json. 

`"qaStatus": null` is now `valid`.

Requested in https://jiracommercial.flir.com/browse/CON-1210