### PR TITLE
Hide SGQLC types from users with generic TypeProxy

### DIFF
--- a/FLIR/conservator/connection.py
+++ b/FLIR/conservator/connection.py
@@ -16,6 +16,7 @@ __all__ = [
     "ConservatorConnection",
 ]
 
+from FLIR.conservator.wrappers import TypeProxy
 
 logger = logging.getLogger(__name__)
 
@@ -241,14 +242,8 @@ class ConservatorConnection:
         fr.exclude_fields(self.fields_manager.get_problematic_paths(type_))
         fr.prepare_query(query)
 
-        ret = getattr(self.run(op), query_name)
-        try:
-            if len(ret) == 0:
-                # no fields were initialized, meaning the value was likely not found
-                return None
-        except TypeError:
-            # this is thrown if the returned type was a primitive without __len__
-            # for instance, a bool or int
-            pass
+        result = self.run(op)
+        field = result._ContainerTypeMeta__fields[query_name]
+        value = getattr(result, query_name)
 
-        return ret
+        return TypeProxy.wrap(self, field.type, value)

--- a/FLIR/conservator/connection.py
+++ b/FLIR/conservator/connection.py
@@ -243,7 +243,6 @@ class ConservatorConnection:
         fr.prepare_query(query)
 
         result = self.run(op)
-        field = result._ContainerTypeMeta__fields[query_name]
         value = getattr(result, query_name)
 
-        return TypeProxy.wrap(self, field.type, value)
+        return TypeProxy.wrap(self, type_, value)

--- a/FLIR/conservator/managers/searchable.py
+++ b/FLIR/conservator/managers/searchable.py
@@ -17,8 +17,7 @@ class SearchableTypeManager(TypeManager):
         """
         return PaginatedQuery(
             self._conservator,
-            self._underlying_type,
-            self._underlying_type.search_query,
+            query=self._underlying_type.search_query,
             search_text=search_text,
             **kwargs,
         )

--- a/FLIR/conservator/paginated_query.py
+++ b/FLIR/conservator/paginated_query.py
@@ -10,8 +10,8 @@ class PaginatedQuery:
     Assume you want to iterate through all the Projects in a project search
     query. You could do something like the following:
 
-    >>> results = PaginatedQuery(conservator, wrapping_type=Project, query=Query.projects, search_text="ADAS")
-    >>> results = results.including_fields("name")
+    >>> results = PaginatedQuery(conservator, query=Query.projects, search_text="ADAS")
+    >>> results = results.including("name")
     >>> for project in results:
     ...     print(project.name)
 

--- a/FLIR/conservator/paginated_query.py
+++ b/FLIR/conservator/paginated_query.py
@@ -16,8 +16,7 @@ class PaginatedQuery:
     ...     print(project.name)
 
     :param conservator: The conservator instance to query.
-    :param wrapping_type: If specified, a :class:`~FLIR.conservator.wrappers.type_proxy.TypeProxy` class to
-        wrap instances in before they are returned.
+    :param wrapping_type: Not required. Included for backwards-compatibility.
     :param query: The GraphQL Query to use.
     :param base_operation: If specified, the base type of the query. Defaults to ``Query``.
     :param fields: Fields to include in the returned objects.
@@ -39,10 +38,9 @@ class PaginatedQuery:
         unpack_field=None,
         **kwargs
     ):
-        assert query is not None  # Unfortunately, this is a required arg, but
-        # for legacy reasons can't be moved before "wrapping_type" and made required.
+        # Unfortunately, query is a required arg, but for backwards-compatibility reasons can't be made required.
+        assert query is not None
         self._conservator = conservator
-        self._wrapping_type = wrapping_type
         self._query = query
         self._base_operation = base_operation
         self.fields = FieldsRequest.create(fields)
@@ -181,9 +179,7 @@ class PaginatedQuery:
             return []
         if self.unpack_field is not None:
             results = getattr(results, self.unpack_field)
-        if self._wrapping_type is None:
-            return results
-        return [self._wrapping_type(self._conservator, i) for i in results]
+        return results
 
     def _passes_filters(self, instance):
         return all(filter_(instance) for filter_ in self.filters)

--- a/FLIR/conservator/util.py
+++ b/FLIR/conservator/util.py
@@ -18,17 +18,8 @@ def to_clean_string(o, first=True):
         s = s.replace("\n", "\n    ")
         s += "\n}"
     elif hasattr(o.__class__, "underlying_type"):
-        s += o.__class__.__name__
+        s += o._instance.__class__.__name__
         for field in o.underlying_type.__field_names__:
-            if not hasattr(o, field):
-                continue
-            value = getattr(o, field)
-            s += f"\n{field}: {to_clean_string(value, False)}"
-        s = s.replace("\n", "\n    ")
-
-    elif hasattr(o, "__field_names__"):
-        s += o.__class__.__name__
-        for field in o.__field_names__:
             if not hasattr(o, field):
                 continue
             value = getattr(o, field)

--- a/FLIR/conservator/wrappers/collection.py
+++ b/FLIR/conservator/wrappers/collection.py
@@ -17,9 +17,6 @@ from FLIR.conservator.util import download_files
 from FLIR.conservator.wrappers.type_proxy import requires_fields
 from FLIR.conservator.wrappers.file_locker import FileLockerType
 from FLIR.conservator.wrappers.queryable import QueryableType
-from FLIR.conservator.wrappers.video import Video
-from FLIR.conservator.wrappers.image import Image
-from FLIR.conservator.wrappers.dataset import Dataset
 
 
 logger = logging.getLogger(__name__)
@@ -165,8 +162,7 @@ class Collection(QueryableType, FileLockerType):
         """Returns a query for all images in this collection."""
         images = PaginatedQuery(
             self._conservator,
-            Image,
-            Query.images,
+            query=Query.images,
             fields=fields,
             search_text=search_text,
             collection_id=self.id,
@@ -182,8 +178,7 @@ class Collection(QueryableType, FileLockerType):
         """Returns a query for all videos in this collection."""
         videos = PaginatedQuery(
             self._conservator,
-            Video,
-            Query.videos,
+            query=Query.videos,
             fields=fields,
             search_text=search_text,
             collection_id=self.id,
@@ -214,8 +209,7 @@ class Collection(QueryableType, FileLockerType):
         """Returns a query for all datasets in this collection."""
         datasets = PaginatedQuery(
             self._conservator,
-            Dataset,
-            Query.datasets,
+            query=Query.datasets,
             fields=fields,
             search_text=search_text,
             collection_id=self.id,

--- a/FLIR/conservator/wrappers/collection.py
+++ b/FLIR/conservator/wrappers/collection.py
@@ -44,13 +44,12 @@ class Collection(QueryableType, FileLockerType):
         with the specified `fields`.
         """
         _input = CreateCollectionInput(name=name, parent_id=self.id)
-        result = self._conservator.query(
+        return self._conservator.query(
             Mutation.create_collection,
             operation_base=Mutation,
             input=_input,
             fields=fields,
         )
-        return Collection(self._conservator, result)
 
     @requires_fields("path")
     def get_child(self, name, make_if_no_exists=False, fields=None):
@@ -134,7 +133,7 @@ class Collection(QueryableType, FileLockerType):
                 return cls.create_from_remote_path(conservator, path, fields)
             else:
                 raise InvalidRemotePathException(path)
-        return Collection(conservator, collection)
+        return collection
 
     def recursively_get_children(self, include_self=False, fields=None):
         """
@@ -221,7 +220,7 @@ class Collection(QueryableType, FileLockerType):
         Remove given media from this collection.
         """
         metadata = MetadataInput(mode="remove", collections=[self.id])
-        self._conservator.query(
+        return self._conservator.query(
             Mutation.update_video,
             operation_base=Mutation,
             id=media_id,
@@ -234,7 +233,7 @@ class Collection(QueryableType, FileLockerType):
         Delete the collection.
         """
         input_ = DeleteCollectionInput(id=self.id)
-        self._conservator.query(
+        return self._conservator.query(
             Mutation.delete_collection, operation_base=Mutation, input=input_
         )
 

--- a/FLIR/conservator/wrappers/dataset.py
+++ b/FLIR/conservator/wrappers/dataset.py
@@ -79,7 +79,6 @@ class Dataset(QueryableType, FileLockerType, MetadataType):
         return PaginatedQuery(
             self._conservator,
             query=Query.dataset_frames_only,
-            wrapping_type=DatasetFrame,
             unpack_field="dataset_frames",
             fields=fields,
             id=self.id,

--- a/FLIR/conservator/wrappers/dataset_frame.py
+++ b/FLIR/conservator/wrappers/dataset_frame.py
@@ -20,7 +20,7 @@ class DatasetFrame(QueryableType):
         Flag the dataset frame.
         """
         input_ = FlagDatasetFrameInput(dataset_frame_id=self.id)
-        self._conservator.query(
+        return self._conservator.query(
             Mutation.flag_dataset_frame,
             operation_base=Mutation,
             fields="id",
@@ -32,7 +32,7 @@ class DatasetFrame(QueryableType):
         Unflag the dataset frame.
         """
         input_ = UnflagDatasetFrameInput(dataset_frame_id=self.id)
-        self._conservator.query(
+        return self._conservator.query(
             Mutation.unflag_dataset_frame,
             operation_base=Mutation,
             fields="id",
@@ -43,7 +43,7 @@ class DatasetFrame(QueryableType):
         """
         Mark the dataset frame as empty.
         """
-        self._conservator.query(
+        return self._conservator.query(
             Mutation.mark_dataset_frame_empty,
             operation_base=Mutation,
             fields="id",
@@ -54,7 +54,7 @@ class DatasetFrame(QueryableType):
         """
         Unmake the dataset frame as empty.
         """
-        self._conservator.query(
+        return self._conservator.query(
             Mutation.unmark_dataset_frame_empty,
             operation_base=Mutation,
             fields="id",
@@ -65,7 +65,7 @@ class DatasetFrame(QueryableType):
         """
         Approve the dataset frame.
         """
-        self._conservator.query(
+        return self._conservator.query(
             Mutation.approve_dataset_frame,
             operation_base=Mutation,
             fields="id",
@@ -76,7 +76,7 @@ class DatasetFrame(QueryableType):
         """
         Request changes to the dataset frame.
         """
-        self._conservator.query(
+        return self._conservator.query(
             Mutation.request_changes_dataset_frame,
             operation_base=Mutation,
             fields="id",
@@ -87,7 +87,7 @@ class DatasetFrame(QueryableType):
         """
         Unset the QA status of the dataset frame.
         """
-        self._conservator.query(
+        return self._conservator.query(
             Mutation.unset_qa_status_frame,
             operation_base=Mutation,
             fields="id",

--- a/FLIR/conservator/wrappers/media.py
+++ b/FLIR/conservator/wrappers/media.py
@@ -149,6 +149,7 @@ class MediaType(QueryableType, FileLockerType, MetadataType):
             completion_tags=completion_tags,
         )
         assert result is True
+        return result
 
     @staticmethod
     def _create(conservator, filename, collection_id=None):
@@ -164,6 +165,8 @@ class MediaType(QueryableType, FileLockerType, MetadataType):
             filename=filename,
             collection_id=collection_id,
         )
+        # We want to re-wrap here, so we don't get Video-specific methods
+        # on something that might become an Image...
         return MediaType(conservator, result)
 
     @staticmethod

--- a/FLIR/conservator/wrappers/metadata.py
+++ b/FLIR/conservator/wrappers/metadata.py
@@ -1,7 +1,6 @@
 import json
 import os
 
-from FLIR.conservator.generated import schema
 from FLIR.conservator.generated.schema import Mutation
 from FLIR.conservator.wrappers import TypeProxy
 from FLIR.conservator.wrappers.type_proxy import requires_fields

--- a/FLIR/conservator/wrappers/project.py
+++ b/FLIR/conservator/wrappers/project.py
@@ -16,15 +16,14 @@ class Project(QueryableType):
 
         Note that this requires the privilege to create projects.
         """
-        result = conservator.query(
+        return conservator.query(
             Mutation.create_project, operation_base=Mutation, name=name, fields=fields
         )
-        return cls(conservator, result)
 
     def delete(self):
         """
         Delete the project.
         """
-        self._conservator.query(
+        return self._conservator.query(
             Mutation.delete_project, operation_base=Mutation, id=self.id
         )

--- a/FLIR/conservator/wrappers/queryable.py
+++ b/FLIR/conservator/wrappers/queryable.py
@@ -20,7 +20,11 @@ class QueryableType(TypeProxy):
     by_id_query = None
 
     def populate_all(self):
-        """Query conservator for all missing fields."""
+        """
+        .. deprecated:: 1.0.2
+            This no longer queries all fields, instead only selecting the defaults, which
+            is equivalent to calling :meth:`populate` with no arguments.
+        """
         self.populate(fields=FieldsRequest())
 
     def populate(self, fields=None):
@@ -33,11 +37,12 @@ class QueryableType(TypeProxy):
 
         fields = FieldsRequest.create(fields)
 
-        result = self._populate(fields)
+        result = self._populate(fields)  # returns a TypeProxy with the new fields
         if result is None:
             raise InvalidIdException(f"Query with id='{self.id}' returned None")
-        for field in result:
-            v = getattr(result, field)
+        # copy over fields from other _instance (to get unproxied)
+        for field in result._instance:
+            v = getattr(result._instance, field)
             setattr(self._instance, field, v)
             self._initialized_fields.append(field)
 

--- a/FLIR/conservator/wrappers/type_proxy.py
+++ b/FLIR/conservator/wrappers/type_proxy.py
@@ -30,6 +30,16 @@ class TypeProxy(object):
     underlying_type = None
 
     def __init__(self, conservator, instance):
+        if isinstance(instance, TypeProxy):
+            # Before queries returned a TypeProxy, many methods had to
+            # wrap the raw type manually. This ensures any old scripts
+            # will not break.
+            self._conservator = instance._conservator
+            self._instance = instance._instance
+            self.underlying_type = instance.underlying_type
+            self._initialized_fields = instance._initialized_fields
+            return
+
         self._conservator = conservator
         self._instance = instance
         if self.underlying_type is None:

--- a/FLIR/conservator/wrappers/type_proxy.py
+++ b/FLIR/conservator/wrappers/type_proxy.py
@@ -14,9 +14,9 @@ class TypeProxy(object):
     When you attempt to access a field, we first check that it exists on the
     underlying instance. If it doesn't, an `AttributeError` will be raised.
 
-    If it does exists, we check to see if a subclass of class:`TypeProxy` is defined
+    If it does exists, we check to see if a subclass of :class:`TypeProxy` is defined
     with a matching ``underlying_type``. If it does, an instance of that subclass is
-    returned with the value. Otherwise, a instance of the generic class:`TypeProxy`
+    returned with the value. Otherwise, a instance of the generic :class:`TypeProxy`
     is returned. This ensures all values returned by queries have the same basic methods
     (like :meth:`TypeProxy.to_json`). The type look-up is compatible with optional and
     list types.

--- a/FLIR/conservator/wrappers/type_proxy.py
+++ b/FLIR/conservator/wrappers/type_proxy.py
@@ -161,6 +161,11 @@ class TypeProxy(object):
         if isinstance(instance, unwrapped_types):
             return instance
 
+        if len(instance) == 0:
+            # No fields were initialized, meaning the value is likely None.
+            # __len__ should exist because we've already checked for int, bool, etc.
+            return None
+
         cls = TypeProxy.get_wrapping_type(type_)
         if isinstance(instance, list):
             return [cls(conservator, i) for i in instance]

--- a/FLIR/conservator/wrappers/type_proxy.py
+++ b/FLIR/conservator/wrappers/type_proxy.py
@@ -6,22 +6,25 @@ from FLIR.conservator.util import to_clean_string
 
 class TypeProxy(object):
     """
-    Wraps an SGQLC object of a specific type with a known ``id``.
-
-    Subclasses can add class and instance methods to add functionality.
-
-    Fields of the underlying instance can be accessed on this instance.
+    Wraps an SGQLC object. Fields of the underlying instance can be accessed on this
+    instance. Subclasses can add class and instance methods to add functionality.
 
     When you attempt to access a field, we first check that it exists on the
-    underlying instance. If it doesn't, an `AttributeError` will be raised. If
-    it does exists, we check to see if its type has a known :class:`TypeProxy`
-    subclass. If it does, a type-proxied instance is returned, otherwise the base
-    SGQLC type is returned. This lookup is compatible with optional and list types.
+    underlying instance. If it doesn't, an `AttributeError` will be raised.
+
+    If it does exists, we check to see if a subclass of class:`TypeProxy` is defined
+    with a matching ``underlying_type``. If it does, an instance of that subclass is
+    returned with the value. Otherwise, a instance of the generic class:`TypeProxy`
+    is returned. This ensures all values returned by queries have the same basic methods
+    (like :meth:`TypeProxy.to_json`). The type look-up is compatible with optional and
+    list types.
+
+    Instances should be created using :func:`TypeProxy.wrap`, which will use the
+    appropriate class and constructor.
 
     :param conservator: The instance of :class:`~FLIR.conservator.conservator.Conservator`
         that created the underlying instance.
-    :param instance: The SGQLC object to wrap, usually returned by running
-        some query.
+    :param instance: The SGQLC object to wrap, usually returned by running some query.
     """
 
     underlying_type = None
@@ -29,16 +32,18 @@ class TypeProxy(object):
     def __init__(self, conservator, instance):
         self._conservator = conservator
         self._instance = instance
+        if self.underlying_type is None:
+            self.underlying_type = instance.__class__
         self._initialized_fields = [field for field in instance]
 
-    def __getattr__(self, item):
-        if item in self._initialized_fields:
-            field = self._instance._ContainerTypeMeta__fields[item]
-            value = getattr(self._instance, item)
+    def __getattr__(self, field_name):
+        if field_name in self._initialized_fields:
+            field = self._instance._ContainerTypeMeta__fields[field_name]
+            value = getattr(self._instance, field_name)
 
-            return TypeProxy.wrap_instance(self._conservator, field.type, value)
+            return TypeProxy.wrap(self._conservator, field.type, value)
 
-        raise AttributeError(f"Unknown or uninitialized attribute: '{item}'")
+        raise AttributeError(f"Unknown or uninitialized attribute: '{field_name}'")
 
     def has_field(self, path):
         """Returns `True` if the current instance has initialized the specified `path`.
@@ -88,15 +93,21 @@ class TypeProxy(object):
         """
         return self._instance.__to_json_value__()
 
+    def __to_json_value__(self):
+        # this is added for backwards compatibility to scripts that may have
+        # been using this method on unwrapped instances.
+        return self._instance.__to_json_value__()
+
     def __str__(self):
         return to_clean_string(self)
 
     @staticmethod
     def has_base_type(base_type, type_):
-        """Returns `True` if `type_` extends `base_type` in the
-        SGQLC type hierarchy.
+        """
+        Returns `True` if `type_` extends `base_type` in the SGQLC type hierarchy.
 
-        For instance, a `[Collection]` has base type `Collection`."""
+        For instance, a ``[Collection]`` has base type ``Collection``.
+        """
         b = type_
         while hasattr(b, "__base__"):
             if b == base_type:
@@ -106,24 +117,33 @@ class TypeProxy(object):
 
     @staticmethod
     def get_wrapping_type(type_):
-        """Gets the :class:`TypeProxy` with an `underlying_type`
-        related to `type_`. If one doesn't exist, returns `None`."""
+        """
+        Gets the :class:`TypeProxy` subclass with an `underlying_type`
+        related to `type_`. If one doesn't exist, returns generic :class:`TypeProxy`.
+
+        This checks the base type. For instance, it will match ``![Video]`` with ``Video``.
+        """
         # rather hacky
-        cls = None
         for subcls in all_subclasses(TypeProxy):
             if TypeProxy.has_base_type(subcls.underlying_type, type_):
-                cls = subcls
-        return cls
+                return subcls
+        return TypeProxy
 
     @staticmethod
-    def wrap_instance(conservator, type_, instance):
-        """Creates a new TypeProxy instance of the appropriate
-        subclass, if one exists."""
-        # rather hacky
+    def wrap(conservator, type_, instance):
+        """
+        Creates a new :class:`TypeProxy` instance of the appropriate subclass, or a generic
+        if no subclass exists for the type. Returns `None` if instance is `None`.
+
+        :param conservator: Conservator instance tied to the instance. Subclasses use this for
+            many instance methods.
+        :param type_: The SGQLC type of the instance to wrap.
+        :param instance: The SGQLC object to wrap.
+        """
+        if instance is None:
+            return None
+
         cls = TypeProxy.get_wrapping_type(type_)
-        if cls is None:
-            # no warping type exists
-            return instance
         if isinstance(instance, list):
             return [cls(conservator, i) for i in instance]
         return cls(conservator, instance)

--- a/FLIR/conservator/wrappers/type_proxy.py
+++ b/FLIR/conservator/wrappers/type_proxy.py
@@ -163,13 +163,17 @@ class TypeProxy(object):
         if isinstance(instance, unwrapped_types):
             return instance
 
+        if isinstance(instance, list):
+            # This isn't the most efficient method, as it recalculates type for each item,
+            # but it handles nested lists correctly... We can refactor if speed ever
+            # becomes a concern.
+            return [TypeProxy.wrap(conservator, type_, item) for item in instance]
+
         if isinstance(instance, sgqlc.types.ContainerType) and len(instance) == 0:
             # No fields were initialized, meaning the value is likely None.
             return None
 
         cls = TypeProxy.get_wrapping_type(type_)
-        if isinstance(instance, list):
-            return [cls(conservator, i) for i in instance]
         return cls(conservator, instance)
 
 

--- a/FLIR/conservator/wrappers/type_proxy.py
+++ b/FLIR/conservator/wrappers/type_proxy.py
@@ -1,5 +1,7 @@
 import functools
 
+import sgqlc.types
+
 from FLIR.conservator.fields_request import FieldsRequest
 from FLIR.conservator.util import to_clean_string
 
@@ -161,9 +163,8 @@ class TypeProxy(object):
         if isinstance(instance, unwrapped_types):
             return instance
 
-        if len(instance) == 0:
+        if isinstance(instance, sgqlc.types.ContainerType) and len(instance) == 0:
             # No fields were initialized, meaning the value is likely None.
-            # __len__ should exist because we've already checked for int, bool, etc.
             return None
 
         cls = TypeProxy.get_wrapping_type(type_)

--- a/FLIR/conservator/wrappers/type_proxy.py
+++ b/FLIR/conservator/wrappers/type_proxy.py
@@ -167,7 +167,9 @@ class TypeProxy(object):
             # This isn't the most efficient method, as it recalculates type for each item,
             # but it handles nested lists correctly... We can refactor if speed ever
             # becomes a concern.
-            return ListTypeProxy(TypeProxy.wrap(conservator, type_, item) for item in instance)
+            return ListTypeProxy(
+                TypeProxy.wrap(conservator, type_, item) for item in instance
+            )
 
         if isinstance(instance, sgqlc.types.ContainerType) and len(instance) == 0:
             # No fields were initialized, meaning the value is likely None.
@@ -182,6 +184,7 @@ class ListTypeProxy(list):
     Identical to built-in `list`, except it provides :meth:`to_json`. This ensures all types
     returned by queries have a :meth:`to_json`.
     """
+
     def to_json(self):
         """
         Returns a `list` suitable for turning into JSON.

--- a/FLIR/conservator/wrappers/type_proxy.py
+++ b/FLIR/conservator/wrappers/type_proxy.py
@@ -167,7 +167,7 @@ class TypeProxy(object):
             # This isn't the most efficient method, as it recalculates type for each item,
             # but it handles nested lists correctly... We can refactor if speed ever
             # becomes a concern.
-            return [TypeProxy.wrap(conservator, type_, item) for item in instance]
+            return ListTypeProxy(TypeProxy.wrap(conservator, type_, item) for item in instance)
 
         if isinstance(instance, sgqlc.types.ContainerType) and len(instance) == 0:
             # No fields were initialized, meaning the value is likely None.
@@ -175,6 +175,20 @@ class TypeProxy(object):
 
         cls = TypeProxy.get_wrapping_type(type_)
         return cls(conservator, instance)
+
+
+class ListTypeProxy(list):
+    """
+    Identical to built-in `list`, except it provides :meth:`to_json`. This ensures all types
+    returned by queries have a :meth:`to_json`.
+    """
+    def to_json(self):
+        """
+        Returns a `list` suitable for turning into JSON.
+        """
+        return [
+            item.to_json() if isinstance(item, TypeProxy) else item for item in self
+        ]
 
 
 class MissingFieldException(Exception):

--- a/FLIR/conservator/wrappers/type_proxy.py
+++ b/FLIR/conservator/wrappers/type_proxy.py
@@ -94,8 +94,8 @@ class TypeProxy(object):
         return self._instance.__to_json_value__()
 
     def __to_json_value__(self):
-        # this is added for backwards compatibility to scripts that may have
-        # been using this method on unwrapped instances.
+        # This is added for backwards compatibility to scripts that may have been
+        # using this method on unwrapped instances. It's undocumented to avoid confusion.
         return self._instance.__to_json_value__()
 
     def __str__(self):
@@ -121,7 +121,7 @@ class TypeProxy(object):
         Gets the :class:`TypeProxy` subclass with an `underlying_type`
         related to `type_`. If one doesn't exist, returns generic :class:`TypeProxy`.
 
-        This checks the base type. For instance, it will match ``![Video]`` with ``Video``.
+        This checks the base type. For instance, it will match ``[Video]!`` with ``Video``.
         """
         # rather hacky
         for subcls in all_subclasses(TypeProxy):

--- a/FLIR/conservator/wrappers/type_proxy.py
+++ b/FLIR/conservator/wrappers/type_proxy.py
@@ -133,15 +133,23 @@ class TypeProxy(object):
     def wrap(conservator, type_, instance):
         """
         Creates a new :class:`TypeProxy` instance of the appropriate subclass, or a generic
-        if no subclass exists for the type. Returns `None` if instance is `None`.
+        if no subclass exists for the type. Scalar types, such as `None`, `str`, `bool`, etc.,
+        are not wrapped and returned as-is.
 
         :param conservator: Conservator instance tied to the instance. Subclasses use this for
             many instance methods.
         :param type_: The SGQLC type of the instance to wrap.
         :param instance: The SGQLC object to wrap.
         """
-        if instance is None:
-            return None
+        unwrapped_types = (
+            type(None),
+            str,
+            int,
+            float,
+            bool,
+        )
+        if isinstance(instance, unwrapped_types):
+            return instance
 
         cls = TypeProxy.get_wrapping_type(type_)
         if isinstance(instance, list):

--- a/FLIR/conservator/wrappers/video.py
+++ b/FLIR/conservator/wrappers/video.py
@@ -77,5 +77,4 @@ class Video(MediaType):
             fields=video_fields,
             id=self.id,
         )
-        wrapped = Video(self._conservator, video)
-        return wrapped.frames
+        return video.frames

--- a/FLIR/conservator/wrappers/video.py
+++ b/FLIR/conservator/wrappers/video.py
@@ -1,8 +1,6 @@
 from FLIR.conservator.fields_request import FieldsRequest
 from FLIR.conservator.generated import schema
-from FLIR.conservator.generated.schema import Query, Mutation
-from FLIR.conservator.paginated_query import PaginatedQuery
-from FLIR.conservator.wrappers.frame import Frame
+from FLIR.conservator.generated.schema import Query
 from FLIR.conservator.wrappers.media import MediaType
 from FLIR.conservator.wrappers.type_proxy import requires_fields
 

--- a/examples/download_associated.py
+++ b/examples/download_associated.py
@@ -1,7 +1,6 @@
 import logging
 
 from FLIR.conservator.conservator import Conservator
-from FLIR.conservator.fields_request import FieldsRequest
 
 logging.basicConfig(level=logging.DEBUG)
 conservator = Conservator.default()

--- a/examples/download_videos.py
+++ b/examples/download_videos.py
@@ -1,7 +1,6 @@
 import os
 
 from FLIR.conservator.conservator import Conservator
-from FLIR.conservator.fields_request import FieldsRequest
 from FLIR.conservator.util import download_files
 
 conservator = Conservator.default()

--- a/examples/list_projects.py
+++ b/examples/list_projects.py
@@ -2,11 +2,10 @@ from FLIR.conservator.conservator import Conservator
 
 conservator = Conservator.default()
 
-# Query all fields:
-# Notice there are errors, and the query needs to be repeated a few times.
-# It also takes a long time to finally execute.
+# Query all default fields:
+# Notice this takes a long time to finish.
 # This is not the recommended way to do a query (unless you actually want
-# all fields).
+# all default fields).
 print("SLOWER WAY:")
 for project in conservator.projects.all():
     print(project.id, project.name)

--- a/examples/populate_dataset.py
+++ b/examples/populate_dataset.py
@@ -1,5 +1,4 @@
 from FLIR.conservator.conservator import Conservator
-from FLIR.conservator.fields_request import FieldsRequest
 
 conservator = Conservator.default()
 
@@ -12,5 +11,5 @@ adas_dataset.populate("name")
 print(adas_dataset)
 
 # Now we want all default fields:
-adas_dataset.populate_all()
+adas_dataset.populate()
 print(adas_dataset)

--- a/examples/query_by_exact_name.py
+++ b/examples/query_by_exact_name.py
@@ -32,10 +32,9 @@ for project in results:
     print(project)
 
 # The above is a common pattern, so it's been added as a function on
-# SearchableTypeManager. Notice: the "name" field must be included in
-# the requested fields.
+# SearchableTypeManager.
 print()
-print("Using built-in by_exact_name")
+print("Using built-in by_exact_name:")
 results = conservator.projects.by_exact_name(project_name, fields="name")
 for project in results:
     assert project.name == project_name

--- a/examples/upload_associated.py
+++ b/examples/upload_associated.py
@@ -1,7 +1,6 @@
 import logging
 
 from FLIR.conservator.conservator import Conservator
-from FLIR.conservator.fields_request import FieldsRequest
 
 logging.basicConfig(level=logging.DEBUG)
 conservator = Conservator.default()

--- a/examples/upload_metadata.py
+++ b/examples/upload_metadata.py
@@ -1,7 +1,6 @@
 import logging
 
 from FLIR.conservator.conservator import Conservator
-from FLIR.conservator.fields_request import FieldsRequest
 
 logging.basicConfig(level=logging.DEBUG)
 conservator = Conservator.default()


### PR DESCRIPTION
Closes #184 

This is a big one... In summary, everything a user touches should now be a `TypeProxy` or a scalar (`int`, `str`, `bool`, etc.)---no more access to SGQLC types.

**This can break scripts that touch private/low level attributes on previously unwrapped types.** But it is a necessary change to let us easily introduce new `TypeProxy`s in the future, and make it easier for users to work with queries. I also doubt such access is done anywhere outside of core CLI.

Previously, SGQLC instances were only turned into a TypeProxy if there was a known subclass with a matching type. That meant non-wrapped types didn't have the TypeProxy methods (like `to_json`). With this change, **all** unknown (and non-scalar) types are wrapped with a generic instance of `TypeProxy`.

This applies in two areas:
 - Accessing a TypeProxy's attributes
 - Conservator.query result

To maintain backwards compatibility:
 - Added `TypeProxy.__to_json_value__()`
 - Allow pass-through of `TypeProxy` as instance to `TypeProxy` constructor.

Other changes:
 - Cleanup of examples, documentation, etc.
 - Removed rewrapping in many helper methods (wouldn't be a problem, but makes it cleaner)
 - `PaginatedQuery.wrapping_type` no longer used/required (still exists as option arg tho, for backwards compatibility)
 - `to_clean_string` no longer handles SGQLC types (everything should fall under TypeProxy branch)


