### PR TITLE
Remove file if download is interrupted, check cache md5

### DIFF
--- a/FLIR/conservator/util.py
+++ b/FLIR/conservator/util.py
@@ -5,7 +5,6 @@ import logging
 import requests
 import tqdm
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -72,18 +71,31 @@ def download_file(path, name, url, remote_md5="", silent=False, no_meter=False):
         if not silent:
             raise FileDownloadException(url)
         else:
-            logger.debug(f"Skipped silent FileDownloadException for url: {url}")
+            logger.warning(f"Skipped silent FileDownloadException for url: {url}")
             return False
+
     size = int(r.headers.get("content-length", 0))
     size_mb = int(size / 1024 / 1024)
     progress = tqdm.tqdm(total=size, disable=no_meter)
     progress.set_description(f"Downloading {name} ({size_mb:.2f} MB)")
     chunk_size = 1024 * 1024
-    with open(file_path, "wb") as fd:
-        for chunk in r.iter_content(chunk_size=chunk_size):
-            progress.update(len(chunk))
-            fd.write(chunk)
-    progress.close()
+
+    try:
+        with open(file_path, "wb") as fd:
+            for chunk in r.iter_content(chunk_size=chunk_size):
+                progress.update(len(chunk))
+                fd.write(chunk)
+    except BaseException as e:
+        # To avoid partial downloads:
+        if os.path.exists(file_path):
+            os.remove(file_path)
+
+        if not silent:
+            raise FileDownloadException from e
+        logger.warning(f"Skipped silent FileDownloadException for url: {url}")
+        return False
+    finally:
+        progress.close()
     return True
 
 


### PR DESCRIPTION
Closes #181 

The md5 of a file in the cache is verified when checking that it exists. This does make `cvc download` resume take noticeably longer, but is probably worth it.

A try/except was added to `download_file`. If interrupted, deletes the file. I tested a few times, and this seems to have solved empty files being left behind after a Control-C mid-download.

