### PR TITLE
Download frames in order they appear

### DIFF
--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python
 import multiprocessing
 import subprocess
 import os
 import json
-import hashlib
 import shutil
 import requests
 import logging
@@ -12,7 +10,7 @@ import time
 
 import jsonschema
 from PIL import Image
-from FLIR.conservator.util import download_files, md5sum_file, download_file
+from FLIR.conservator.util import md5sum_file, download_file
 
 logger = logging.getLogger(__name__)
 

--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -437,7 +437,7 @@ class LocalDataset:
         for md5, paths_to_link in hashes_required.items():
             cache_path = self.get_cache_path(md5)
             if self.exists_in_cache(md5):
-                LocalDataset._add_links(cache_path, paths_to_link)
+                LocalDataset._add_links(cache_path, paths_to_link, use_symlink)
                 cache_hits += 1
                 logger.info(f"Skipping {md5}: already downloaded.")
                 continue

--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -1,3 +1,4 @@
+import collections
 import multiprocessing
 import subprocess
 import os
@@ -382,9 +383,10 @@ class LocalDataset:
         if include_analytics:
             os.makedirs(self.analytics_path, exist_ok=True)
 
-        # dict stores unique keys in order of insertion. this maps hash -> [links]
         frame_count = 0
-        hashes_required = dict()
+        # Stores unique keys in order of insertion. This maps hash -> [links]
+        # dict is unordered until Python version 3.7+ (we support 3.6)
+        hashes_required = collections.OrderedDict()
         for frame in self.get_frames():
             video_metadata = frame.get("videoMetadata", {})
             video_id = video_metadata.get("videoId", "")

--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -318,24 +318,10 @@ class LocalDataset:
     def get_cache_path(self, md5):
         return os.path.join(self.cache_path, md5[:2], md5[2:])
 
-    def get_sorted_frames(self):
+    def get_frames(self):
         with open(self.index_path) as f:
             data = json.load(f)
-
-        video_indexes = {}
-        for i, video in enumerate(data.get("videos", [])):
-            video_indexes[video["id"]] = i
-
-        def key(frame):
-            video_metadata = frame.get("videoMetadata", {})
-            video_id = video_metadata.get("videoId", "")
-            frame_index = video_metadata.get("frameIndex", 0)
-            video_index = video_indexes.get(video_id, len(video_indexes))
-            return video_index, frame_index
-
-        frames = data.get("frames", [])
-
-        return sorted(frames, key=key)
+        return data.get("frames", [])
 
     def clean_data_dir(self):
         for file in os.listdir(self.data_path):
@@ -401,7 +387,7 @@ class LocalDataset:
         # dict stores unique keys in order of insertion. this maps hash -> [links]
         frame_count = 0
         hashes_required = dict()
-        for frame in self.get_sorted_frames():
+        for frame in self.get_frames():
             video_metadata = frame.get("videoMetadata", {})
             video_id = video_metadata.get("videoId", "")
             frame_index = video_metadata["frameIndex"]


### PR DESCRIPTION
Frames were being downloaded out of order because we used a `set` of hashes (unordered). Now we use a `OrderedDict`

Old CVC would link as files were downloaded. Now we do the same. This involved quite a bit of refactoring because of our reduction to unique hashes.
