### PR TITLE
Stop using operation_base in query

### DIFF
--- a/FLIR/conservator/connection.py
+++ b/FLIR/conservator/connection.py
@@ -194,14 +194,11 @@ class ConservatorConnection:
         Provides an alternative way to prepare and run SGQLC operations.
 
         :param query: The SGQLC query to run.
-        :param operation_base: The base object of the query.
-            Defaults to :class:`FLIR.conservator.generated.schema.Query`.
+        :param operation_base: Not required. Included for backwards-compatibility.
         :param fields: A :class:`FLIR.conservator.fields_request.FieldsRequest` of
             the fields to include (or exclude) in the results.
         :param kwargs: These named parameters are passed as arguments to the query.
         """
-        if operation_base is None:
-            operation_base = schema.query_type
 
         tries = 0
 
@@ -209,7 +206,7 @@ class ConservatorConnection:
             # TODO: This retry logic is pretty messy. We should refactor and add tests.
             try:
                 try:
-                    return self._query(query, operation_base, fields, **kwargs)
+                    return self._query(query, fields, **kwargs)
                 except ConservatorGraphQLServerError as e:
                     self._handle_errors(e.errors, query.type)
             except ConservatorGraphQLServerError as e:
@@ -231,9 +228,9 @@ class ConservatorConnection:
                 logger.debug("Retrying request after exception: " + str(e))
                 logger.debug("Retry #" + str(tries))
 
-    def _query(self, query, operation_base, fields, **kwargs):
+    def _query(self, query, fields, **kwargs):
         type_ = query.type
-        op = Operation(operation_base)
+        op = Operation(query.container)
         query_name = query.name
         query = getattr(op, query_name)
         query(**kwargs)

--- a/FLIR/conservator/paginated_query.py
+++ b/FLIR/conservator/paginated_query.py
@@ -160,11 +160,7 @@ class PaginatedQuery:
 
     def _do_query(self, page, limit):
         results = self._conservator.query(
-            query=self._query,
-            fields=self.fields,
-            page=page,
-            limit=limit,
-            **self.kwargs
+            query=self._query, fields=self.fields, page=page, limit=limit, **self.kwargs
         )
         return results
 

--- a/FLIR/conservator/paginated_query.py
+++ b/FLIR/conservator/paginated_query.py
@@ -18,7 +18,7 @@ class PaginatedQuery:
     :param conservator: The conservator instance to query.
     :param wrapping_type: Not required. Included for backwards-compatibility.
     :param query: The GraphQL Query to use.
-    :param base_operation: If specified, the base type of the query. Defaults to ``Query``.
+    :param base_operation: Not required. Included for backwards-compatibility.
     :param fields: Fields to include in the returned objects.
     :param page_size: The page size to use when submitting requests.
     :param unpack_field: If specified, instead of directly returning the resulting object(s) from a query,
@@ -42,7 +42,6 @@ class PaginatedQuery:
         assert query is not None
         self._conservator = conservator
         self._query = query
-        self._base_operation = base_operation
         self.fields = FieldsRequest.create(fields)
         self._page = 0
         self._limit = page_size
@@ -162,7 +161,6 @@ class PaginatedQuery:
     def _do_query(self, page, limit):
         results = self._conservator.query(
             query=self._query,
-            operation_base=self._base_operation,
             fields=self.fields,
             page=page,
             limit=limit,

--- a/FLIR/conservator/wrappers/collection.py
+++ b/FLIR/conservator/wrappers/collection.py
@@ -46,7 +46,6 @@ class Collection(QueryableType, FileLockerType):
         _input = CreateCollectionInput(name=name, parent_id=self.id)
         return self._conservator.query(
             Mutation.create_collection,
-            operation_base=Mutation,
             input=_input,
             fields=fields,
         )
@@ -222,7 +221,6 @@ class Collection(QueryableType, FileLockerType):
         metadata = MetadataInput(mode="remove", collections=[self.id])
         return self._conservator.query(
             Mutation.update_video,
-            operation_base=Mutation,
             id=media_id,
             metadata=metadata,
             fields="id",
@@ -234,7 +232,8 @@ class Collection(QueryableType, FileLockerType):
         """
         input_ = DeleteCollectionInput(id=self.id)
         return self._conservator.query(
-            Mutation.delete_collection, operation_base=Mutation, input=input_
+            Mutation.delete_collection,
+            input=input_,
         )
 
     @requires_fields("name", "file_locker_files", "child_ids")

--- a/FLIR/conservator/wrappers/dataset.py
+++ b/FLIR/conservator/wrappers/dataset.py
@@ -127,9 +127,7 @@ class Dataset(QueryableType, FileLockerType, MetadataType):
         method to fail.
         """
         return self._conservator.query(
-            query=Query.commit_history_by_id,
-            fields=fields,
-            id=self.repository.master
+            query=Query.commit_history_by_id, fields=fields, id=self.repository.master
         )
 
     def get_commit_by_id(self, commit_id="HEAD", fields=None):

--- a/FLIR/conservator/wrappers/dataset.py
+++ b/FLIR/conservator/wrappers/dataset.py
@@ -11,7 +11,6 @@ from FLIR.conservator.generated.schema import (
 )
 from FLIR.conservator.paginated_query import PaginatedQuery
 from FLIR.conservator.util import download_file
-from FLIR.conservator.wrappers.dataset_frame import DatasetFrame
 from FLIR.conservator.wrappers.file_locker import FileLockerType
 from FLIR.conservator.wrappers.metadata import MetadataType
 from FLIR.conservator.wrappers.queryable import QueryableType
@@ -46,7 +45,6 @@ class Dataset(QueryableType, FileLockerType, MetadataType):
         input_ = CreateDatasetInput(name=name, collection_ids=collection_ids)
         dataset = conservator.query(
             Mutation.create_dataset,
-            operation_base=Mutation,
             input=input_,
             fields=fields,
         )
@@ -58,7 +56,8 @@ class Dataset(QueryableType, FileLockerType, MetadataType):
         """
         input_ = DeleteDatasetInput(id=self.id)
         self._conservator.query(
-            Mutation.delete_dataset, operation_base=Mutation, input=input_
+            Mutation.delete_dataset,
+            input=input_,
         )
 
     def generate_metadata(self):
@@ -67,7 +66,6 @@ class Dataset(QueryableType, FileLockerType, MetadataType):
         """
         return self._conservator.query(
             Mutation.generate_dataset_metadata,
-            operation_base=Mutation,
             dataset_id=self.id,
         )
 
@@ -97,38 +95,9 @@ class Dataset(QueryableType, FileLockerType, MetadataType):
         )
         return self._conservator.query(
             Mutation.add_frames_to_dataset,
-            operation_base=Mutation,
             fields=fields,
             input=_input,
         )
-
-    def generate_signed_metadata_upload_url(self, filename, content_type):
-        """
-        Returns a signed url for uploading metadata with the given `filename` and
-        `content_type`.
-        """
-        result = self._conservator.query(
-            Mutation.generate_signed_dataset_metadata_upload_url,
-            operation_base=Mutation,
-            dataset_id=self.id,
-            content_type=content_type,
-            filename=filename,
-        )
-        return result.signed_url
-
-    def generate_signed_locker_upload_url(self, filename, content_type):
-        """
-        Returns a signed url for uploading a new file locker file with the given `filename` and
-        `content_type`.
-        """
-        result = self._conservator.query(
-            Mutation.generate_signed_dataset_file_locker_upload_url,
-            operation_base=Mutation,
-            dataset_id=self.id,
-            content_type=content_type,
-            filename=filename,
-        )
-        return result.signed_url
 
     def get_git_url(self):
         """Returns the Git URL used for cloning this Dataset."""
@@ -145,7 +114,6 @@ class Dataset(QueryableType, FileLockerType, MetadataType):
         user = self._conservator.get_user()
         return self._conservator.query(
             Mutation.commit_dataset,
-            operation_base=Mutation,
             dataset_id=self.id,
             commit_message=message,
             user_id=user.id,
@@ -159,7 +127,9 @@ class Dataset(QueryableType, FileLockerType, MetadataType):
         method to fail.
         """
         return self._conservator.query(
-            query=Query.commit_history_by_id, fields=fields, id=self.repository.master
+            query=Query.commit_history_by_id,
+            fields=fields,
+            id=self.repository.master
         )
 
     def get_commit_by_id(self, commit_id="HEAD", fields=None):

--- a/FLIR/conservator/wrappers/dataset_frame.py
+++ b/FLIR/conservator/wrappers/dataset_frame.py
@@ -22,7 +22,6 @@ class DatasetFrame(QueryableType):
         input_ = FlagDatasetFrameInput(dataset_frame_id=self.id)
         return self._conservator.query(
             Mutation.flag_dataset_frame,
-            operation_base=Mutation,
             fields="id",
             input=input_,
         )
@@ -34,7 +33,6 @@ class DatasetFrame(QueryableType):
         input_ = UnflagDatasetFrameInput(dataset_frame_id=self.id)
         return self._conservator.query(
             Mutation.unflag_dataset_frame,
-            operation_base=Mutation,
             fields="id",
             input=input_,
         )
@@ -45,7 +43,6 @@ class DatasetFrame(QueryableType):
         """
         return self._conservator.query(
             Mutation.mark_dataset_frame_empty,
-            operation_base=Mutation,
             fields="id",
             id=self.id,
         )
@@ -56,7 +53,6 @@ class DatasetFrame(QueryableType):
         """
         return self._conservator.query(
             Mutation.unmark_dataset_frame_empty,
-            operation_base=Mutation,
             fields="id",
             id=self.id,
         )
@@ -67,7 +63,6 @@ class DatasetFrame(QueryableType):
         """
         return self._conservator.query(
             Mutation.approve_dataset_frame,
-            operation_base=Mutation,
             fields="id",
             id=self.id,
         )
@@ -78,7 +73,6 @@ class DatasetFrame(QueryableType):
         """
         return self._conservator.query(
             Mutation.request_changes_dataset_frame,
-            operation_base=Mutation,
             fields="id",
             id=self.id,
         )
@@ -89,7 +83,6 @@ class DatasetFrame(QueryableType):
         """
         return self._conservator.query(
             Mutation.unset_qa_status_frame,
-            operation_base=Mutation,
             fields="id",
             id=self.id,
         )

--- a/FLIR/conservator/wrappers/file_locker.py
+++ b/FLIR/conservator/wrappers/file_locker.py
@@ -51,9 +51,7 @@ class FileLockerType(TypeProxy):
             "filename": filename,
             "content_type": content_type,
         }
-        result = self._conservator.query(
-            self.file_locker_gen_url, **mutation_args
-        )
+        result = self._conservator.query(self.file_locker_gen_url, **mutation_args)
         return result.signed_url
 
     @requires_fields("file_locker_files")

--- a/FLIR/conservator/wrappers/file_locker.py
+++ b/FLIR/conservator/wrappers/file_locker.py
@@ -1,6 +1,5 @@
 import os
 
-from FLIR.conservator.generated import schema
 from FLIR.conservator.generated.schema import Mutation
 from FLIR.conservator.wrappers import TypeProxy
 from FLIR.conservator.wrappers.type_proxy import requires_fields
@@ -53,7 +52,7 @@ class FileLockerType(TypeProxy):
             "content_type": content_type,
         }
         result = self._conservator.query(
-            self.file_locker_gen_url, operation_base=Mutation, **mutation_args
+            self.file_locker_gen_url, **mutation_args
         )
         return result.signed_url
 
@@ -89,7 +88,6 @@ class FileLockerType(TypeProxy):
         mutation_args = {self.id_type: self.id, "filename": filename}
         result = self._conservator.query(
             self.file_locker_remove,
-            operation_base=Mutation,
             fields="id",
             **mutation_args,
         )

--- a/FLIR/conservator/wrappers/frame.py
+++ b/FLIR/conservator/wrappers/frame.py
@@ -26,17 +26,6 @@ class Frame(QueryableType):
         ids = [self.id]
         return self._conservator.query(Frame.by_ids_query, fields=fields, ids=ids)[0]
 
-    def get_annotations(self, fields=None):
-        """
-        Returns the frame's annotations with the specified `fields`.
-        """
-        return self._conservator.query(
-            schema.Frame.annotations,
-            operation_base=schema.Frame,
-            fields=fields,
-            id=self.id,
-        )
-
     def add_annotation(self, annotation_create, fields=None):
         """
         Adds an annotation using the specified `annotation_create` object.
@@ -46,7 +35,6 @@ class Frame(QueryableType):
         assert isinstance(annotation_create, AnnotationCreate)
         return self._conservator.query(
             Mutation.create_annotation,
-            operation_base=Mutation,
             fields=fields,
             frame_id=self.id,
             annotation=annotation_create,
@@ -61,7 +49,6 @@ class Frame(QueryableType):
         assert isinstance(prediction_create, PredictionCreate)
         return self._conservator.query(
             Mutation.create_prediction,
-            operation_base=Mutation,
             fields=fields,
             frame_id=self.id,
             prediction=prediction_create,

--- a/FLIR/conservator/wrappers/media.py
+++ b/FLIR/conservator/wrappers/media.py
@@ -91,7 +91,6 @@ class MediaType(QueryableType, FileLockerType, MetadataType):
         """
         return self._conservator.query(
             Mutation.process_video,
-            operation_base=Mutation,
             fields=fields,
             id=self.id,
             metadata_url=metadata_url,
@@ -108,7 +107,6 @@ class MediaType(QueryableType, FileLockerType, MetadataType):
         """
         result = self._conservator.query(
             Mutation.generate_signed_multipart_video_upload_url,
-            operation_base=Mutation,
             part_number=part_number,
             upload_id=upload_id,
             video_id=self.id,
@@ -122,7 +120,6 @@ class MediaType(QueryableType, FileLockerType, MetadataType):
         """
         upload_id = self._conservator.query(
             Mutation.initiate_video_upload,
-            operation_base=Mutation,
             video_id=self.id,
             filename=filename,
         )
@@ -142,7 +139,6 @@ class MediaType(QueryableType, FileLockerType, MetadataType):
             completion_tags = []
         result = self._conservator.query(
             Mutation.complete_video_upload,
-            operation_base=Mutation,
             video_id=self.id,
             filename=filename,
             upload_id=upload_id,
@@ -161,7 +157,6 @@ class MediaType(QueryableType, FileLockerType, MetadataType):
         """
         result = conservator.query(
             Mutation.create_video,
-            operation_base=Mutation,
             filename=filename,
             collection_id=collection_id,
         )
@@ -242,5 +237,6 @@ class MediaType(QueryableType, FileLockerType, MetadataType):
         remove it from **all** collections.
         """
         return self._conservator.query(
-            Mutation.remove_video, operation_base=Mutation, id=self.id
+            Mutation.remove_video,
+            id=self.id,
         )

--- a/FLIR/conservator/wrappers/metadata.py
+++ b/FLIR/conservator/wrappers/metadata.py
@@ -50,9 +50,7 @@ class MetadataType(TypeProxy):
             "filename": filename,
             "content_type": content_type,
         }
-        result = self._conservator.query(
-            self.metadata_gen_url, **mutation_args
-        )
+        result = self._conservator.query(self.metadata_gen_url, **mutation_args)
         return result.signed_url
 
     def _confirm_metadata_upload(self, url):
@@ -63,9 +61,7 @@ class MetadataType(TypeProxy):
             "id": self.id,
             "url": url,
         }
-        result = self._conservator.query(
-            self.metadata_confirm_url, **mutation_args
-        )
+        result = self._conservator.query(self.metadata_confirm_url, **mutation_args)
         return result
 
     @requires_fields("metadata", "filename")

--- a/FLIR/conservator/wrappers/metadata.py
+++ b/FLIR/conservator/wrappers/metadata.py
@@ -51,7 +51,7 @@ class MetadataType(TypeProxy):
             "content_type": content_type,
         }
         result = self._conservator.query(
-            self.metadata_gen_url, operation_base=Mutation, **mutation_args
+            self.metadata_gen_url, **mutation_args
         )
         return result.signed_url
 
@@ -64,7 +64,7 @@ class MetadataType(TypeProxy):
             "url": url,
         }
         result = self._conservator.query(
-            self.metadata_confirm_url, operation_base=Mutation, **mutation_args
+            self.metadata_confirm_url, **mutation_args
         )
         return result
 

--- a/FLIR/conservator/wrappers/project.py
+++ b/FLIR/conservator/wrappers/project.py
@@ -17,7 +17,7 @@ class Project(QueryableType):
         Note that this requires the privilege to create projects.
         """
         return conservator.query(
-            Mutation.create_project, operation_base=Mutation, name=name, fields=fields
+            Mutation.create_project, name=name, fields=fields
         )
 
     def delete(self):
@@ -25,5 +25,5 @@ class Project(QueryableType):
         Delete the project.
         """
         return self._conservator.query(
-            Mutation.delete_project, operation_base=Mutation, id=self.id
+            Mutation.delete_project, id=self.id
         )

--- a/FLIR/conservator/wrappers/project.py
+++ b/FLIR/conservator/wrappers/project.py
@@ -16,14 +16,10 @@ class Project(QueryableType):
 
         Note that this requires the privilege to create projects.
         """
-        return conservator.query(
-            Mutation.create_project, name=name, fields=fields
-        )
+        return conservator.query(Mutation.create_project, name=name, fields=fields)
 
     def delete(self):
         """
         Delete the project.
         """
-        return self._conservator.query(
-            Mutation.delete_project, id=self.id
-        )
+        return self._conservator.query(Mutation.delete_project, id=self.id)


### PR DESCRIPTION
Closes #193 

Not needed--base can be gotten from query.container

The kwarg is still added to the method signature, just ignored. This won't affect any scripts that do provide it