### PR TITLE
Add support for named configs, improve config management

### DIFF
--- a/FLIR/conservator/cli/__init__.py
+++ b/FLIR/conservator/cli/__init__.py
@@ -1,5 +1,6 @@
 import click
-from FLIR.conservator.config import Config
+
+from FLIR.conservator.cli.config import config_
 from FLIR.conservator.cli.managers import get_manager_command
 from FLIR.conservator.cli.interactive import interactive
 from FLIR.conservator.conservator import Conservator
@@ -35,23 +36,6 @@ def main(log):
     logging.basicConfig(level=levels[log])
 
 
-@main.command(help="View or delete the current config")
-@click.option(
-    "--delete", is_flag=True, help="If passed, delete the default credentials."
-)
-def config(delete):
-    if delete:
-        Config.delete_saved_default_config()
-        return
-    default_config = Config.default()
-    click.echo("Default config:")
-    click.echo(f"  URL: {default_config.url}")
-    click.echo(f"  Key: {default_config.key}")
-    click.echo(f"  Max Retries: {default_config.max_retries}")
-    click.echo(f"  CVC Cache Path: {default_config.cvc_cache_path}")
-    click.echo(f"Corresponds to email: {Conservator.default().get_email()}")
-
-
 @main.command(help="Print information on the current user")
 def whoami():
     conservator = Conservator.default()
@@ -59,6 +43,7 @@ def whoami():
     click.echo(to_clean_string(user))
 
 
+main.add_command(config_)
 main.add_command(
     get_manager_command(CollectionManager, schema.Collection, "collections")
 )

--- a/FLIR/conservator/cli/config.py
+++ b/FLIR/conservator/cli/config.py
@@ -1,0 +1,65 @@
+import json
+
+import click
+
+from FLIR.conservator.config import Config
+from FLIR.conservator.conservator import Conservator
+
+
+@click.group(name="config", help="Manage configs")
+def config_():
+    pass
+
+
+@config_.command(help="Delete config")
+@click.argument("name", default="default")
+def delete(name):
+    if click.confirm(
+        "Are you sure? You can use conservator config edit to change individual values."
+    ):
+        Config.delete_saved_named_config(name)
+
+
+@config_.command(help="View config")
+@click.argument("name", default="default")
+def view(name):
+    config = Config.from_name(name)
+    conservator = Conservator(config)
+    click.echo(config)
+    click.echo(f"Corresponds to email: {conservator.get_email()}")
+
+
+@config_.command(name="list", help="List available config names")
+def list_():
+    for name in Config.saved_config_names():
+        click.echo(name)
+
+
+@config_.command(name="edit", help="Edit config")
+@click.argument("name", default="default")
+def edit_(name):
+    config = Config.from_name(name)
+    config_json = json.dumps(config.to_dict(), indent=2)
+    value = click.edit(config_json)
+    if value is not None:
+        new_json = json.loads(value)
+        new_config = Config.from_dict(new_json)
+        new_config.save_to_named_config(name)
+        click.echo(f"Edited {name}")
+        return
+    click.echo(f"No changes.")
+
+
+@config_.command(name="set-default", help="Set default config")
+@click.argument("name")
+def set_default(name):
+    config = Config.from_name(name)
+    config.save_to_default_config()
+    click.echo("Saved.")
+
+
+@config_.command(help="Create a config")
+@click.argument("name")
+def create(name):
+    config = Config.from_input()
+    config.save_to_named_config(name)

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -14,7 +14,7 @@ your current Python Environment.
 Before you can use the command, you need to tell Conservator-CLI your API key and
 other settings. Log in to your conservator instance, and find your API key. Then run::
 
-    $ conservator config
+    $ conservator config create default
 
 Conservator CLI will ask you for your API key, and some other settings.
 The defaults should work for most users. These settings will be
@@ -25,9 +25,12 @@ saved in a config file for future use. To verify that they're correct, run::
 This should output information on your account. You're now free to start
 with :doc:`cli_quickstart` or :doc:`cvc_guide`.
 
-If you want to change credentials, you can delete your config by running::
+If you want to change credentials, you can edit your config by running::
 
-    $ conservator config --delete
+    $ conservator config edit
+
+For developers working with multiple conservator instances, you can add
+multiple configs. See ``conservator config --help`` for more info.
 
 Dependency
 ----------


### PR DESCRIPTION
Closes #164 

```
Usage: conservator config [OPTIONS] COMMAND [ARGS]...

  Manage configs

Options:
  --help  Show this message and exit.

Commands:
  create       Create a config
  delete       Delete config
  edit         Edit config
  list         List available config names
  set-default  Set default config
  view         View config
```