### PR TITLE
Move get_frame methods to MediaType

### DIFF
--- a/FLIR/conservator/managers/media.py
+++ b/FLIR/conservator/managers/media.py
@@ -5,9 +5,8 @@ import os
 import time
 
 from FLIR.conservator.fields_request import FieldsRequest
-from FLIR.conservator.util import upload_file
 from FLIR.conservator.managers.type_manager import AmbiguousIdentifierException
-from FLIR.conservator.wrappers.media import MediaType, MediaUploadRequest, MediaCompare
+from FLIR.conservator.wrappers.media import MediaType, MediaUploadRequest
 from FLIR.conservator.wrappers.queryable import InvalidIdException
 
 logger = logging.getLogger(__name__)
@@ -27,7 +26,7 @@ class MediaTypeManager:
         self._conservator = conservator
 
     def from_path(self, string, fields="id"):
-        if not "/" in string:
+        if "/" not in string:
             return None
 
         # start by path lookup

--- a/FLIR/conservator/wrappers/image.py
+++ b/FLIR/conservator/wrappers/image.py
@@ -18,3 +18,11 @@ class Image(MediaType):
         :param local_path: Path to local copy of file for comparison with remote.
         """
         return MediaType.verify_md5(local_path, self.image_md5)
+
+    def get_frame(self, fields=None):
+        """
+        Get the frame of the Image. Because images only have one frame, this is
+        the same as :meth:`MediaType.get_frame_by_index` with index `0`.
+        """
+        return self.get_frame_by_index(0, fields=fields)
+

--- a/FLIR/conservator/wrappers/image.py
+++ b/FLIR/conservator/wrappers/image.py
@@ -25,4 +25,3 @@ class Image(MediaType):
         the same as :meth:`MediaType.get_frame_by_index` with index `0`.
         """
         return self.get_frame_by_index(0, fields=fields)
-

--- a/FLIR/conservator/wrappers/media.py
+++ b/FLIR/conservator/wrappers/media.py
@@ -3,6 +3,7 @@ import os
 import traceback
 from dataclasses import dataclass
 
+from FLIR.conservator.fields_request import FieldsRequest
 from FLIR.conservator.generated.schema import Mutation
 from FLIR.conservator.util import md5sum_file, download_file, upload_file
 from FLIR.conservator.wrappers import QueryableType
@@ -240,3 +241,53 @@ class MediaType(QueryableType, FileLockerType, MetadataType):
             Mutation.remove_video,
             id=self.id,
         )
+
+    def get_frame_by_index(self, index, fields=None):
+        """
+        Returns a single frame at a specific `index` in the video.
+        """
+        return self._query_frames(frame_index=index, fields=fields)[0]
+
+    def get_all_frames_paginated(self, fields=None):
+        """
+        Yields all frames in the video, 15 at a time, using
+        :meth:`get_paginated_frames`.
+
+        This is only useful if you're dealing with very long videos
+        and want to paginate frames yourself. If the video is short,
+        you could just use ``populate("frames")`` to get all frames.
+        """
+        start = 0
+        while True:
+            frames = self._paginated_frames(start, fields=fields)
+            yield from frames
+            # frame pagination size is hard-coded to 15 in conservator
+            if len(frames) < 15:
+                break
+            start += 15
+
+    def _paginated_frames(self, start_index=0, fields=None):
+        """
+        Returns 15 frames, starting with `start_index`.
+        """
+        return self._query_frames(start_frame_index=start_index, fields=fields)
+
+    def _query_frames(self, start_frame_index=None, frame_index=None, fields=None):
+        fields = FieldsRequest.create(fields)
+
+        video_fields = {
+            "frames": {
+                "start_frame_index": start_frame_index,
+                "frame_index": frame_index,
+            }
+        }
+        for path, value in fields.paths.items():
+            new_path = "frames." + path
+            video_fields[new_path] = value
+
+        video = self._conservator.query(
+            query=self.by_id_query,
+            fields=video_fields,
+            id=self.id,
+        )
+        return video.frames

--- a/FLIR/conservator/wrappers/video.py
+++ b/FLIR/conservator/wrappers/video.py
@@ -1,4 +1,3 @@
-from FLIR.conservator.fields_request import FieldsRequest
 from FLIR.conservator.generated import schema
 from FLIR.conservator.generated.schema import Query
 from FLIR.conservator.wrappers.media import MediaType
@@ -28,53 +27,3 @@ class Video(MediaType):
         return self._conservator.query(
             Query.annotations_by_video_id, fields=fields, id=self.id
         )
-
-    def get_frame_by_index(self, index, fields=None):
-        """
-        Returns a single frame at a specific `index` in the video.
-        """
-        return self._query_frames(frame_index=index, fields=fields)[0]
-
-    def get_all_frames_paginated(self, fields=None):
-        """
-        Yields all frames in the video, 15 at a time, using
-        :meth:`get_paginated_frames`.
-
-        This is only useful if you're dealing with very long videos
-        and want to paginate frames yourself. If the video is short,
-        you could just use ``populate("frames")`` to get all frames.
-        """
-        start = 0
-        while True:
-            frames = self._paginated_frames(start, fields=fields)
-            yield from frames
-            # frame pagination size is hard-coded to 15 in conservator
-            if len(frames) < 15:
-                break
-            start += 15
-
-    def _paginated_frames(self, start_index=0, fields=None):
-        """
-        Returns 15 frames, starting with `start_index`.
-        """
-        return self._query_frames(start_frame_index=start_index, fields=fields)
-
-    def _query_frames(self, start_frame_index=None, frame_index=None, fields=None):
-        fields = FieldsRequest.create(fields)
-
-        video_fields = {
-            "frames": {
-                "start_frame_index": start_frame_index,
-                "frame_index": frame_index,
-            }
-        }
-        for path, value in fields.paths.items():
-            new_path = "frames." + path
-            video_fields[new_path] = value
-
-        video = self._conservator.query(
-            query=self.by_id_query,
-            fields=video_fields,
-            id=self.id,
-        )
-        return video.frames


### PR DESCRIPTION
Closes #186 

Get fromo ID not useful: `Frame.from_id(id)` and `Frame.populate(fields)` already exist

Get frame by index already exists for `Video`, moved to `MediaType`.

Added `Image.get_frame`
