### PR TITLE
Fix project name error when creating a new remote collection path

### DIFF
--- a/FLIR/conservator/wrappers/collection.py
+++ b/FLIR/conservator/wrappers/collection.py
@@ -102,7 +102,7 @@ class Collection(QueryableType, FileLockerType):
             )
         except InvalidRemotePathException:
             root = Collection.create_root(
-                conservator, name=root_path, fields=temp_fields
+                conservator, name=split_path[0], fields=temp_fields
             )
 
         current = root


### PR DESCRIPTION
If a project doesn't exist, create_from_remote_path() would produce a bad
GraphQL query with a '/' in front of the project name.  Generally, new
projects won't need to be created, but test code will be likely to be
creating new projects on a local development Conservator server, so it
helps if this works correctly.