### PR TITLE
Use a single progress bar for cvc download

### DIFF
--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -11,6 +11,8 @@ import time
 
 import jsonschema
 from PIL import Image
+import tqdm
+
 from FLIR.conservator.util import md5sum_file, download_file
 
 logger = logging.getLogger(__name__)
@@ -329,8 +331,10 @@ class LocalDataset:
                 os.remove(file_path)
 
     @staticmethod
-    def _download_and_link(path, name, url, paths_to_link, use_symlink, no_meter):
-        result = download_file(path, name, url, silent=True, no_meter=no_meter)
+    def _download_and_link(asset):
+        # we use imap (istarmap doesn't exist) so we need to unpack arguments
+        path, name, url, paths_to_link, use_symlink = asset
+        result = download_file(path, name, url, silent=True, no_meter=True)
         downloaded_path = os.path.join(path, name)
         LocalDataset._add_links(downloaded_path, paths_to_link, use_symlink)
         return result
@@ -385,6 +389,7 @@ class LocalDataset:
         if include_analytics:
             os.makedirs(self.analytics_path, exist_ok=True)
 
+        logger.info(f"Getting frames from index.json...")
         frame_count = 0
         # Stores unique keys in order of insertion. This maps hash -> [links]
         # dict is unordered until Python version 3.7+ (we support 3.6)
@@ -420,23 +425,38 @@ class LocalDataset:
         # the data directory. Because we have the cache, we can just delete everything.
         self.clean_data_dir()
 
+        logger.info(f"Checking cache...")
         cache_hits = 0
-        assets = []  # (path, name, url, paths_to_link, use_symlink, no_meter)
+        assets = []  # (path, name, url, paths_to_link, use_symlink)
         for md5, paths_to_link in hashes_required.items():
             cache_path = self.get_cache_path(md5)
             if self.exists_in_cache(md5):
                 LocalDataset._add_links(cache_path, paths_to_link, use_symlink)
                 cache_hits += 1
-                logger.info(f"Skipping {md5}: already downloaded.")
+                logger.debug(f"Skipping {md5}: already downloaded.")
                 continue
             path, name = os.path.split(cache_path)
             url = self.conservator.get_dvc_hash_url(md5)
-            asset = (path, name, url, paths_to_link, use_symlink, no_meter)
+            asset = (path, name, url, paths_to_link, use_symlink)
             logger.debug(f"Going to download {md5}")
             assets.append(asset)
 
-        pool = multiprocessing.Pool(process_count)  # defaults to CPU count
-        results = pool.starmap(LocalDataset._download_and_link, assets)
+        logger.info(f"Total frames: {frame_count}")
+        logger.info(f"  Unique hashes: {len(hashes_required)}")
+        logger.info(f"  Already downloaded: {cache_hits}")
+        logger.info(f"  Missing: {len(assets)}")
+        logger.info(f"Going to download {len(assets)} new frames using {process_count} processes.")
+        if process_count == 10:  # default
+            yellow = "\x1b[33;21m"
+            cyan = "\x1b[36;21m"
+            reset = "\x1b[0m"
+            logger.info(f"{yellow}If you're running from {cyan}cvc download{yellow} and have a fast connection, you "
+                        f"might be able to speed this up by rerunning with the -p (--process_count) option.{reset}")
+            logger.info(f"{yellow}For instance: {cyan}cvc download -p 50{reset}")
+        with multiprocessing.Pool(process_count) as pool:
+            iterator = pool.imap(LocalDataset._download_and_link, assets)
+            progress = tqdm.tqdm(iterable=iterator, desc="Downloading new frames", total=len(assets), disable=no_meter)
+            results = list(progress)  # We need to consume the results as they're output to update the progress bar.
 
         # we double check everything downloaded
         failures = 0
@@ -449,9 +469,6 @@ class LocalDataset:
                 failures += 1
         successes = len(assets) - failures
 
-        logger.info(f"Total frames: {frame_count}")
-        logger.info(f"  Unique hashes: {len(hashes_required)}")
-        logger.info(f"  Cache hits: {cache_hits}")
         logger.info(f"Downloads attempted: {len(assets)}")
         logger.info(f"  Reported {sum(results)} successes.")
         logger.info(f"  Successful downloads: {successes}")

--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -10,9 +10,8 @@ import pkg_resources
 import time
 
 import jsonschema
-from PIL import Image
 import tqdm
-
+from PIL import Image
 from FLIR.conservator.util import md5sum_file, download_file
 
 logger = logging.getLogger(__name__)

--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -445,18 +445,27 @@ class LocalDataset:
         logger.info(f"  Unique hashes: {len(hashes_required)}")
         logger.info(f"  Already downloaded: {cache_hits}")
         logger.info(f"  Missing: {len(assets)}")
-        logger.info(f"Going to download {len(assets)} new frames using {process_count} processes.")
+        logger.info(
+            f"Going to download {len(assets)} new frames using {process_count} processes."
+        )
         if process_count == 10:  # default
             yellow = "\x1b[33;21m"
             cyan = "\x1b[36;21m"
             reset = "\x1b[0m"
-            logger.info(f"{yellow}If you're running from {cyan}cvc download{yellow} and have a fast connection, you "
-                        f"might be able to speed this up by rerunning with the -p (--process_count) option.{reset}")
+            logger.info(
+                f"{yellow}If you're running from {cyan}cvc download{yellow} and have a fast connection, you "
+                f"might be able to speed this up by rerunning with the -p (--process_count) option.{reset}"
+            )
             logger.info(f"{yellow}For instance: {cyan}cvc download -p 50{reset}")
         with multiprocessing.Pool(process_count) as pool:
-            iterator = pool.imap(LocalDataset._download_and_link, assets)
-            progress = tqdm.tqdm(iterable=iterator, desc="Downloading new frames", total=len(assets), disable=no_meter)
-            results = list(progress)  # We need to consume the results as they're output to update the progress bar.
+            progress = tqdm.tqdm(
+                iterable=pool.imap(LocalDataset._download_and_link, assets),
+                desc="Downloading new frames",
+                total=len(assets),
+                disable=no_meter,
+            )
+            # We need to consume the results as they're output to update the progress bar, we use list.
+            results = list(progress)
 
         # we double check everything downloaded
         failures = 0

--- a/FLIR/conservator/util.py
+++ b/FLIR/conservator/util.py
@@ -57,10 +57,17 @@ def download_file(path, name, url, remote_md5="", silent=False, no_meter=False):
             return True
 
     logger.debug(f"Downloading {name} from {url}")
-    r = requests.get(url, stream=True, allow_redirects=True)
-    if r.status_code != 200:
+    try:
+        r = requests.get(url, stream=True, allow_redirects=True)
+        if r.status_code != 200:
+            if not silent:
+                raise FileDownloadException(url)
+            else:
+                logger.warning(f"Skipped silent FileDownloadException for url: {url}")
+                return False
+    except requests.exceptions.ConnectionError as e:
         if not silent:
-            raise FileDownloadException(url)
+            raise FileDownloadException(url) from e
         else:
             logger.warning(f"Skipped silent FileDownloadException for url: {url}")
             return False


### PR DESCRIPTION
This was briefly discussed in slack. 

This makes it much more clear what's going on, and how much time is left for everything to be downloaded. I changed some of the status reporting, and added a reminder about the `-p` option. I encountered an connection error, so added an exception handler to make sure it's caught and the download continues.

Tested with a 3k image dataset, seemed to work great.
