### PR TITLE
Config as option

### DIFF
--- a/FLIR/conservator/cli/__init__.py
+++ b/FLIR/conservator/cli/__init__.py
@@ -41,16 +41,7 @@ def main(log, config):
     }
     logging.basicConfig(level=levels[log])
 
-    if config:
-        try:
-            conservator = Conservator(Config.from_name(config))
-        except AttributeError:
-            raise RuntimeError(
-                f"Unknown/Invalid Conservator config '{config}'"
-            ) from None
-    else:
-        conservator = Conservator.default()
-
+    conservator = Conservator.create(config_name=config)
     ctx = click.get_current_context()
     ctx.ensure_object(dict)
     ctx.obj["conservator"] = conservator

--- a/FLIR/conservator/cli/cvc.py
+++ b/FLIR/conservator/cli/cvc.py
@@ -7,6 +7,7 @@ import logging
 
 from click import get_current_context
 
+from FLIR.conservator.config import Config
 from FLIR.conservator.conservator import Conservator
 from FLIR.conservator.local_dataset import LocalDataset
 
@@ -16,7 +17,7 @@ def pass_valid_local_dataset(func):
     def wrapper(*args, **kwargs):
         ctx_obj = get_current_context().obj
         path = ctx_obj["cvc_local_path"]
-        conservator = Conservator.default()
+        conservator = ctx_obj["conservator"]
         # raises InvalidLocalDatasetPath if the path does not point to a
         # valid LocalDataset (defined as a directory containing index.json).
         local_dataset = LocalDataset(conservator, path)
@@ -34,10 +35,15 @@ def pass_valid_local_dataset(func):
     help="Logging level, defaults to INFO",
 )
 @click.option(
+    "--config",
+    default=None,
+    help="Conservator config name, use default credentials if not specified",
+)
+@click.option(
     "-p", "--path", default=".", help="Path to dataset, defaults to current directory"
 )
 @click.pass_context
-def main(ctx, log, path):
+def main(ctx, log, path, config):
     levels = {
         "DEBUG": logging.DEBUG,
         "INFO": logging.INFO,
@@ -46,7 +52,19 @@ def main(ctx, log, path):
         "CRITICAL": logging.CRITICAL,
     }
     logging.basicConfig(level=levels[log])
-    ctx.obj = {"cvc_local_path": path}
+    if config:
+        try:
+            conservator = Conservator(Config.from_name(config))
+        except AttributeError:
+            raise RuntimeError(
+                f"Unknown/Invalid Conservator config '{config}'"
+            ) from None
+    else:
+        conservator = Conservator.default()
+
+    ctx.ensure_object(dict)
+    ctx.obj["conservator"] = conservator
+    ctx.obj["cvc_local_path"] = path
 
 
 @main.command(help="Clone a dataset by id, path, or name (if unique)")
@@ -63,7 +81,7 @@ def main(ctx, log, path):
 )
 @click.pass_context
 def clone(ctx, identifier, path, checkout):
-    conservator = Conservator.default()
+    conservator = ctx.obj["conservator"]
     dataset = conservator.datasets.from_string(identifier)
     cloned = LocalDataset.clone(dataset, path)
     if checkout is not None:
@@ -216,12 +234,9 @@ def publish(local_dataset, message, skip_validation):
 @click.pass_context
 def cvc(ctx, path):
     # This command is added to conservator CLI.
-    # It is the same as main sans the log level stuff.
-    # The conservator command handles logging, and would
-    # result in confusing behavior if included twice.
-    conservator = Conservator.default()
-    if not ctx.obj:
-        ctx.obj = {}
+    # It is the same as main() except it skips things that toplevel
+    # conservator command already handles (logging and conservator config,
+    # and would result in confusing behavior if included twice.
     ctx.obj["cvc_local_path"] = path
 
 

--- a/FLIR/conservator/cli/cvc.py
+++ b/FLIR/conservator/cli/cvc.py
@@ -52,16 +52,8 @@ def main(ctx, log, path, config):
         "CRITICAL": logging.CRITICAL,
     }
     logging.basicConfig(level=levels[log])
-    if config:
-        try:
-            conservator = Conservator(Config.from_name(config))
-        except AttributeError:
-            raise RuntimeError(
-                f"Unknown/Invalid Conservator config '{config}'"
-            ) from None
-    else:
-        conservator = Conservator.default()
 
+    conservator = Conservator.create(config_name=config)
     ctx.ensure_object(dict)
     ctx.obj["conservator"] = conservator
     ctx.obj["cvc_local_path"] = path

--- a/FLIR/conservator/cli/interactive.py
+++ b/FLIR/conservator/cli/interactive.py
@@ -399,7 +399,8 @@ def run_shell_command(command):
 @click.command(help="An interactive shell for exploring conservator")
 def interactive():
     global conservator
-    conservator = Conservator.default()
+    ctx_obj = click.get_current_context().obj
+    conservator = ctx_obj["conservator"]
 
     click.secho(
         """This is an interactive conservator "shell" that simulates the directory\n"""

--- a/FLIR/conservator/cli/managers.py
+++ b/FLIR/conservator/cli/managers.py
@@ -43,7 +43,8 @@ def fields_request(func):
 
 def get_manager_command(type_manager, sgqlc_type, name):
     def get_instance():
-        conservator = Conservator.default()
+        ctx_obj = click.get_current_context().obj
+        conservator = ctx_obj["conservator"]
         return type_manager(conservator)
 
     @click.group(name=name, help=f"View or manage {name}")
@@ -403,7 +404,8 @@ def get_manager_command(type_manager, sgqlc_type, name):
             help="If given and a remote path is provided, collections will be created to reach the remote path",
         )
         def upload(localpath, remote_collection, remote_name, create_collections):
-            conservator = Conservator.default()
+            ctx_obj = click.get_current_context().obj
+            conservator = ctx_obj["conservator"]
             if create_collections:
                 collection = conservator.collections.from_remote_path(
                     path=remote_collection, make_if_no_exist=True, fields="id"

--- a/FLIR/conservator/conservator.py
+++ b/FLIR/conservator/conservator.py
@@ -87,6 +87,24 @@ class Conservator(ConservatorConnection):
         """
         return Conservator(Config.default(save=save))
 
+    @staticmethod
+    def create(config_name=None, save=True):
+        """
+        Returns a :class:`Conservator` using named config if given, and otherwise
+        creates a default instance via `Conservator.default()`.
+        """
+        conservator = None
+        if config_name:
+            try:
+                conservator = Conservator(Config.from_name(config_name))
+            except AttributeError:
+                raise RuntimeError(
+                    f"Unknown/Invalid Conservator config '{config}'"
+                ) from None
+        else:
+            conservator = Conservator.default()
+        return conservator
+
     def get_media_instance_from_id(self, media_id, fields=None):
         """
         Returns a Video or Image object from an ID. These types are checked in


### PR DESCRIPTION
Support specifying non-default Conservator config by name in CLI commands

Useful for advanced users and developers who have access to more than one FLIR Conservator account (either different users or different servers)

    conservator --config prod collections download --media --recursive /AndresTest ./AndresTest
    conservator --config staging collections upload -c --media --recursive /AndresTest ./AndresTest

    cvc --config priv_user clone super-test-dset