### PR TITLE
Use docker inspect to find IP of mongo

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -80,9 +80,15 @@ def mongo_client(using_kubernetes, conservator_domain):
         port_forward_proc.terminate()
     else:  # Using docker
         mongo_addr_proc = subprocess.run(
-            ["docker", "inspect", "conservator_mongo", "-f", "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}"],
+            [
+                "docker",
+                "inspect",
+                "conservator_mongo",
+                "-f",
+                "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
+            ],
             stdout=subprocess.PIPE,
-            text=True
+            text=True,
         )
         domain = mongo_addr_proc.stdout.strip()
         yield pymongo.MongoClient(host=[f"{domain}:27017"])

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -46,8 +46,12 @@ def mongo_client(using_kubernetes):
         yield pymongo.MongoClient("mongodb://localhost:27030/")
         port_forward_proc.terminate()
     else:  # Using docker
-        # TODO: Get mongo container IP using docker inspect
-        domain = "172.17.0.2"
+        mongo_addr_proc = subprocess.run(
+            ["docker", "inspect", "conservator_mongo", "-f", "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}"],
+            stdout=subprocess.PIPE,
+            text=True
+        )
+        domain = mongo_addr_proc.stdout.strip()
         port = 27017
         yield pymongo.MongoClient(host=[f"{domain}:{port}"])
 


### PR DESCRIPTION
When running off of docker (not using kind), the mongodb box's IP was hardcoded.

Now it is fetched with the `docker inspect` command. This only affects local dev deployment using docker (from run-webapp.sh, run-workers.sh, etc.)

**This PR is branched from `kube-integration`. Review that first!**