### PR TITLE
collections upload: don't throw exception on metadata with missing media

### DIFF
--- a/FLIR/conservator/managers/__init__.py
+++ b/FLIR/conservator/managers/__init__.py
@@ -139,12 +139,12 @@ class CollectionManager(SearchableTypeManager):
 
                 try:
                     media = self._conservator.get_media_instance_from_id(media_id)
+                    media.upload_metadata(file_path)
                 # oops importing real exception UnknownMediaIdException causes import loop
                 except:
                     logger.error(
                         "Skip metadata %s (media id=%s not found)", file_path, media_id
                     )
-                media.upload_metadata(file_path)
 
         if associated_files:
             logger.info("Uploading associated files to collection %s", collection.path)


### PR DESCRIPTION
When a metadata file had a media id that couldn't be found in Conservator,
the upload method was printing an error message but then tried to
upload the metadata anyways, causing an exception that aborts
the rest of the collection upload

  File "conservator-cli/FLIR/conservator/managers/__init__.py",
  line 147, in upload
      media.upload_metadata(file_path)
      AttributeError: 'bool' object has no attribute 'upload_metadata

Only attempt the metadata upload if its corresponding media could
actually be found.