### PR TITLE
backfill dataclasses module for python 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ requests
 black
 Pillow
 jsonschema
+dataclasses; python_version<'3.7'
 pymongo

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ INSTALL_REQUIRES = [
     "requests",
     "Pillow",
     "jsonschema",
+    "dataclasses; python_version<'3.7'",
 ]
 
 if sys.platform.startswith("win"):


### PR DESCRIPTION
Turns out dataclasses module was added in python 3.7, so fix the list
of dependencies by adding the external backport module for python 3.6