### PR TITLE
specify minimum click dependency version as 7.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 wheel
 sphinx
 sgqlc
-click
+click >= 7
 tqdm
 pytest
 requests

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open("README.md", "r") as fh:
 # in requirements.txt instead.
 INSTALL_REQUIRES = [
     "sgqlc",
-    "click",
+    "click >= 7",
     "tqdm",
     "requests",
     "Pillow",


### PR DESCRIPTION
With click 6.x, both 'conservator' and 'cvc' tools error out with

    TypeError: main() got an unexpected keyword argument 'log_level'