### PR TITLE
Jenkins cleanup

### DIFF
--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -3,7 +3,7 @@ pipeline {
     dockerfile {
       dir "test"
       label "docker"
-      args "-u root --privileged -v /var/run/docker.sock:/var/run/docker.sock"
+      args "-u root --init --privileged -v /var/run/docker.sock:/var/run/docker.sock"
     }
   }
   stages {

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -46,7 +46,11 @@ pipeline {
             sh "kind create cluster --config=test/integration/kind.yaml"
             // Modify kubectl to look through bridge connection.
             // Requires --insecure-skip-tls-verify on kubectl command.
-            sh "sed -i 's/0.0.0.0/172.17.0.1/g' ~/.kube/config"
+            sh """
+                GW=\$(ip route list default | sed 's/.*via //; s/ .*//')
+                echo "using \$GW as bridge ip"
+                sed -i "s/0.0.0.0/\$GW/g" ~/.kube/config
+            """
             sh "kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml --insecure-skip-tls-verify"
           }
         }

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8-slim
 
 # Install standalone apt dependencies
 RUN apt-get update \
-    && apt-get install -y git make curl
+    && apt-get install -y git make curl iproute2
 
 # Configure git
 RUN git config --global user.name "FLIR QA SERVICE" \

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -52,7 +52,10 @@ def running_in_testing_docker():
 def conservator_domain(using_kubernetes):
     # If we are in a container, we connect to host.
     if running_in_testing_docker():
-        return "172.17.0.1"  # Host IP
+        host_ip = subprocess.getoutput(
+            "ip route list default | sed 's/.*via //; s/ .*//' "
+        )
+        return host_ip  # Host IP
     # Running on host
     return "localhost"
 


### PR DESCRIPTION
Having jenkins run docker with '--init' is supposed to tell docker to clean up child processes after the temporary container created for testing is stopped. This should prevent accumulation of zombie processes inside the jenkins slave container.