### PR TITLE
Add --init flag to testing docker args

### DIFF
--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -3,7 +3,7 @@ pipeline {
     dockerfile {
       dir "test"
       label "docker"
-      args "-u root --privileged -v /var/run/docker.sock:/var/run/docker.sock"
+      args "--init -u root --privileged -v /var/run/docker.sock:/var/run/docker.sock"
     }
   }
   stages {


### PR DESCRIPTION
This should let testing container collect its zombie processes

Entirely possible `--init` also needs to be added to the start_worker script for lemon jenkins worker
