### PR TITLE
Add tests for FileLockerType

### DIFF
--- a/FLIR/conservator/wrappers/file_locker.py
+++ b/FLIR/conservator/wrappers/file_locker.py
@@ -59,6 +59,11 @@ class FileLockerType(TypeProxy):
         path = os.path.join(path, "associated_files")
         os.makedirs(path, exist_ok=True)
         downloads = []
+
+        if self.file_locker_files is None:
+            # Sometimes it can be null?
+            return
+
         for file in self.file_locker_files:
             local_path = os.path.join(path, file.name)
             download = DownloadRequest(url=file.url, local_path=local_path)
@@ -74,7 +79,7 @@ class FileLockerType(TypeProxy):
             content_type = self.default_file_type
         url = self._generate_file_locker_url(file_path, content_type)
         try:
-            self._conservator.upload(url=url, local_path=file_path)
+            self._conservator.files.upload(url=url, local_path=file_path)
         except FileUploadException as e:
             raise FileLockerUploadException from e
         return True

--- a/test/data/txt/lorem.txt
+++ b/test/data/txt/lorem.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:458c5d52872d566cc322c8a22e72f2267a21f4cbf48575201ea5fee2e3a00510
+size 3425

--- a/test/integration/test_file_locker.py
+++ b/test/integration/test_file_locker.py
@@ -74,7 +74,7 @@ def test_dataset_file_locker(conservator, test_data, tmp_cwd):
     assert len(dataset.file_locker_files) == 0
 
 
-def test_dataset_file_locker(conservator, test_data, tmp_cwd):
+def test_collection_file_locker(conservator, test_data, tmp_cwd):
     conservator.collections.create_from_remote_path("/Test")
 
     collection = conservator.collections.all().first()

--- a/test/integration/test_file_locker.py
+++ b/test/integration/test_file_locker.py
@@ -5,19 +5,22 @@ from FLIR.conservator.util import md5sum_file
 from conftest import upload_media
 
 
-class TestFileLockerImage:
+class TestFileLockerMedia:
     @pytest.fixture(scope="class", autouse=True)
     def init_media(self, conservator, test_data):
         MEDIA = [
             # local_path, remote_path, remote_name
             (test_data / "jpg" / "cat_2.jpg", "/Cats", "My cat.jpg"),
         ]
+        # File locker files for images and videos are treated the same.
         upload_media(conservator, MEDIA)
 
     def test_file_locker_files_start_null(self, conservator):
         image = conservator.images.all().first()
         image.populate("file_locker_files")
-        # For some reason, it starts as null
+        # For some reason, it starts as null.
+        # This behavior is unique to Image/Video.
+        # JIRA Ticket CON-1472 is tracking this discrepancy.
         assert image.file_locker_files is None
         # assert len(image.file_locker_files) == 0
 
@@ -59,3 +62,109 @@ class TestFileLockerImage:
         # But now that it has files, it's not null it's an empty list.
         assert len(image.file_locker_files) == 0
 
+
+class TestFileLockerDataset:
+    @pytest.fixture(scope="class", autouse=True)
+    def init_media(self, conservator, test_data):
+        MEDIA = [
+            # local_path, remote_path, remote_name
+            (test_data / "jpg" / "cat_2.jpg", "/Cats", "My cat.jpg"),
+        ]
+        upload_media(conservator, MEDIA)
+        conservator.datasets.create("Test dataset")
+
+    def test_file_locker_files_start_null(self, conservator):
+        dataset = conservator.datasets.all().first()
+        dataset.populate("file_locker_files")
+        assert len(dataset.file_locker_files) == 0
+
+    def test_download_empty(self, conservator, tmp_cwd):
+        dataset = conservator.datasets.all().first()
+        dataset.download_associated_files(".")
+
+        assert os.path.exists("associated_files")
+        assert os.path.isdir("associated_files")
+        assert len(os.listdir("associated_files")) == 0
+
+    def test_upload(self, conservator, test_data):
+        path = test_data / "txt" / "lorem.txt"
+        dataset = conservator.datasets.all().first()
+        dataset.upload_associated_file(path)
+
+        dataset.populate("file_locker_files")
+        assert len(dataset.file_locker_files) == 1
+        assert dataset.file_locker_files[0].name == "lorem.txt"
+
+    def test_download(self, conservator, tmp_cwd, test_data):
+        # !!! WE ARE IN A CLASS: State is saved from previous test !!!
+        path = test_data / "txt" / "lorem.txt"
+        dataset = conservator.datasets.all().first()
+        dataset.download_associated_files(".")
+
+        assert len(os.listdir("associated_files")) == 1
+        assert os.path.exists("associated_files/lorem.txt")
+        assert os.path.isfile("associated_files/lorem.txt")
+
+        assert md5sum_file("associated_files/lorem.txt") == md5sum_file(path)
+
+    def test_remove(self, conservator):
+        # !!! WE ARE IN A CLASS: State is saved from previous test !!!
+        dataset = conservator.datasets.all().first()
+        dataset.remove_associated_file("lorem.txt")
+
+        dataset.populate("file_locker_files")
+        # But now that it has files, it's not null it's an empty list.
+        assert len(dataset.file_locker_files) == 0
+
+
+class TestFileLockerCollection:
+    @pytest.fixture(scope="class", autouse=True)
+    def init_media(self, conservator, test_data):
+        MEDIA = [
+            # local_path, remote_path, remote_name
+            (test_data / "jpg" / "cat_2.jpg", "/Cats", "My cat.jpg"),
+        ]
+        upload_media(conservator, MEDIA)
+
+    def test_file_locker_files_start_null(self, conservator):
+        collection = conservator.collections.all().first()
+        collection.populate("file_locker_files")
+        assert len(collection.file_locker_files) == 0
+
+    def test_download_empty(self, conservator, tmp_cwd):
+        collection = conservator.collections.all().first()
+        collection.download_associated_files(".")
+
+        assert os.path.exists("associated_files")
+        assert os.path.isdir("associated_files")
+        assert len(os.listdir("associated_files")) == 0
+
+    def test_upload(self, conservator, test_data):
+        path = test_data / "txt" / "lorem.txt"
+        collection = conservator.collections.all().first()
+        collection.upload_associated_file(path)
+
+        collection.populate("file_locker_files")
+        assert len(collection.file_locker_files) == 1
+        assert collection.file_locker_files[0].name == "lorem.txt"
+
+    def test_download(self, conservator, tmp_cwd, test_data):
+        # !!! WE ARE IN A CLASS: State is saved from previous test !!!
+        path = test_data / "txt" / "lorem.txt"
+        collection = conservator.collections.all().first()
+        collection.download_associated_files(".")
+
+        assert len(os.listdir("associated_files")) == 1
+        assert os.path.exists("associated_files/lorem.txt")
+        assert os.path.isfile("associated_files/lorem.txt")
+
+        assert md5sum_file("associated_files/lorem.txt") == md5sum_file(path)
+
+    def test_remove(self, conservator):
+        # !!! WE ARE IN A CLASS: State is saved from previous test !!!
+        collection = conservator.collections.all().first()
+        collection.remove_associated_file("lorem.txt")
+
+        collection.populate("file_locker_files")
+        # But now that it has files, it's not null it's an empty list.
+        assert len(collection.file_locker_files) == 0

--- a/test/integration/test_file_locker.py
+++ b/test/integration/test_file_locker.py
@@ -1,0 +1,61 @@
+import os
+import pytest as pytest
+
+from FLIR.conservator.util import md5sum_file
+from conftest import upload_media
+
+
+class TestFileLockerImage:
+    @pytest.fixture(scope="class", autouse=True)
+    def init_media(self, conservator, test_data):
+        MEDIA = [
+            # local_path, remote_path, remote_name
+            (test_data / "jpg" / "cat_2.jpg", "/Cats", "My cat.jpg"),
+        ]
+        upload_media(conservator, MEDIA)
+
+    def test_file_locker_files_start_null(self, conservator):
+        image = conservator.images.all().first()
+        image.populate("file_locker_files")
+        # For some reason, it starts as null
+        assert image.file_locker_files is None
+        # assert len(image.file_locker_files) == 0
+
+    def test_download_empty(self, conservator, tmp_cwd):
+        image = conservator.images.all().first()
+        image.download_associated_files(".")
+
+        assert os.path.exists("associated_files")
+        assert os.path.isdir("associated_files")
+        assert len(os.listdir("associated_files")) == 0
+
+    def test_upload(self, conservator, test_data):
+        path = test_data / "txt" / "lorem.txt"
+        image = conservator.images.all().first()
+        image.upload_associated_file(path)
+
+        image.populate("file_locker_files")
+        assert len(image.file_locker_files) == 1
+        assert image.file_locker_files[0].name == "lorem.txt"
+
+    def test_download(self, conservator, tmp_cwd, test_data):
+        # !!! WE ARE IN A CLASS: State is saved from previous test !!!
+        path = test_data / "txt" / "lorem.txt"
+        image = conservator.images.all().first()
+        image.download_associated_files(".")
+
+        assert len(os.listdir("associated_files")) == 1
+        assert os.path.exists("associated_files/lorem.txt")
+        assert os.path.isfile("associated_files/lorem.txt")
+
+        assert md5sum_file("associated_files/lorem.txt") == md5sum_file(path)
+
+    def test_remove(self, conservator):
+        # !!! WE ARE IN A CLASS: State is saved from previous test !!!
+        image = conservator.images.all().first()
+        image.remove_associated_file("lorem.txt")
+
+        image.populate("file_locker_files")
+        # But now that it has files, it's not null it's an empty list.
+        assert len(image.file_locker_files) == 0
+

--- a/test/integration/test_file_locker.py
+++ b/test/integration/test_file_locker.py
@@ -5,166 +5,102 @@ from FLIR.conservator.util import md5sum_file
 from conftest import upload_media
 
 
-class TestFileLockerMedia:
-    @pytest.fixture(scope="class", autouse=True)
-    def init_media(self, conservator, test_data):
-        MEDIA = [
-            # local_path, remote_path, remote_name
-            (test_data / "jpg" / "cat_2.jpg", "/Cats", "My cat.jpg"),
-        ]
-        # File locker files for images and videos are treated the same.
-        upload_media(conservator, MEDIA)
+def test_media_file_locker(conservator, test_data, tmp_cwd):
+    path = test_data / "jpg" / "cat_0.jpg"
+    media_id = conservator.media.upload(path)
+    conservator.media.wait_for_processing(media_id, check_frequency_seconds=1)
 
-    def test_file_locker_files_start_null(self, conservator):
-        image = conservator.images.all().first()
-        image.populate("file_locker_files")
-        # For some reason, it starts as null.
-        # This behavior is unique to Image/Video.
-        # JIRA Ticket CON-1472 is tracking this discrepancy.
-        assert image.file_locker_files is None
-        # assert len(image.file_locker_files) == 0
+    image = conservator.images.all().first()
+    image.populate("file_locker_files")
+    # For some reason, it starts as null.
+    # This behavior is unique to Image/Video.
+    # JIRA Ticket CON-1472 is tracking this discrepancy.
+    assert image.file_locker_files is None
+    # assert len(image.file_locker_files) == 0
 
-    def test_download_empty(self, conservator, tmp_cwd):
-        image = conservator.images.all().first()
-        image.download_associated_files(".")
+    image.download_associated_files(".")
+    assert os.path.exists("associated_files")
+    assert os.path.isdir("associated_files")
+    assert len(os.listdir("associated_files")) == 0
+    path = test_data / "txt" / "lorem.txt"
+    image.upload_associated_file(path)
+    image.populate("file_locker_files")
+    assert len(image.file_locker_files) == 1
+    assert image.file_locker_files[0].name == "lorem.txt"
 
-        assert os.path.exists("associated_files")
-        assert os.path.isdir("associated_files")
-        assert len(os.listdir("associated_files")) == 0
+    image = conservator.images.all().first()
+    image.download_associated_files(".")
+    assert len(os.listdir("associated_files")) == 1
+    assert os.path.exists("associated_files/lorem.txt")
+    assert os.path.isfile("associated_files/lorem.txt")
+    assert md5sum_file("associated_files/lorem.txt") == md5sum_file(path)
 
-    def test_upload(self, conservator, test_data):
-        path = test_data / "txt" / "lorem.txt"
-        image = conservator.images.all().first()
-        image.upload_associated_file(path)
-
-        image.populate("file_locker_files")
-        assert len(image.file_locker_files) == 1
-        assert image.file_locker_files[0].name == "lorem.txt"
-
-    def test_download(self, conservator, tmp_cwd, test_data):
-        # !!! WE ARE IN A CLASS: State is saved from previous test !!!
-        path = test_data / "txt" / "lorem.txt"
-        image = conservator.images.all().first()
-        image.download_associated_files(".")
-
-        assert len(os.listdir("associated_files")) == 1
-        assert os.path.exists("associated_files/lorem.txt")
-        assert os.path.isfile("associated_files/lorem.txt")
-
-        assert md5sum_file("associated_files/lorem.txt") == md5sum_file(path)
-
-    def test_remove(self, conservator):
-        # !!! WE ARE IN A CLASS: State is saved from previous test !!!
-        image = conservator.images.all().first()
-        image.remove_associated_file("lorem.txt")
-
-        image.populate("file_locker_files")
-        # But now that it has files, it's not null it's an empty list.
-        assert len(image.file_locker_files) == 0
+    image = conservator.images.all().first()
+    image.remove_associated_file("lorem.txt")
+    image.populate("file_locker_files")
+    # But now that it has files, it's not null it's an empty list.
+    assert len(image.file_locker_files) == 0
 
 
-class TestFileLockerDataset:
-    @pytest.fixture(scope="class", autouse=True)
-    def init_media(self, conservator, test_data):
-        MEDIA = [
-            # local_path, remote_path, remote_name
-            (test_data / "jpg" / "cat_2.jpg", "/Cats", "My cat.jpg"),
-        ]
-        upload_media(conservator, MEDIA)
-        conservator.datasets.create("Test dataset")
+def test_dataset_file_locker(conservator, test_data, tmp_cwd):
+    conservator.datasets.create("Test dataset")
 
-    def test_file_locker_files_start_null(self, conservator):
-        dataset = conservator.datasets.all().first()
-        dataset.populate("file_locker_files")
-        assert len(dataset.file_locker_files) == 0
+    dataset = conservator.datasets.all().first()
+    dataset.populate("file_locker_files")
+    assert len(dataset.file_locker_files) == 0
 
-    def test_download_empty(self, conservator, tmp_cwd):
-        dataset = conservator.datasets.all().first()
-        dataset.download_associated_files(".")
+    dataset = conservator.datasets.all().first()
+    dataset.download_associated_files(".")
+    assert os.path.exists("associated_files")
+    assert os.path.isdir("associated_files")
+    assert len(os.listdir("associated_files")) == 0
 
-        assert os.path.exists("associated_files")
-        assert os.path.isdir("associated_files")
-        assert len(os.listdir("associated_files")) == 0
+    path = test_data / "txt" / "lorem.txt"
+    dataset = conservator.datasets.all().first()
+    dataset.upload_associated_file(path)
+    dataset.populate("file_locker_files")
+    assert len(dataset.file_locker_files) == 1
+    assert dataset.file_locker_files[0].name == "lorem.txt"
 
-    def test_upload(self, conservator, test_data):
-        path = test_data / "txt" / "lorem.txt"
-        dataset = conservator.datasets.all().first()
-        dataset.upload_associated_file(path)
+    dataset.download_associated_files(".")
+    assert len(os.listdir("associated_files")) == 1
+    assert os.path.exists("associated_files/lorem.txt")
+    assert os.path.isfile("associated_files/lorem.txt")
+    assert md5sum_file("associated_files/lorem.txt") == md5sum_file(path)
 
-        dataset.populate("file_locker_files")
-        assert len(dataset.file_locker_files) == 1
-        assert dataset.file_locker_files[0].name == "lorem.txt"
-
-    def test_download(self, conservator, tmp_cwd, test_data):
-        # !!! WE ARE IN A CLASS: State is saved from previous test !!!
-        path = test_data / "txt" / "lorem.txt"
-        dataset = conservator.datasets.all().first()
-        dataset.download_associated_files(".")
-
-        assert len(os.listdir("associated_files")) == 1
-        assert os.path.exists("associated_files/lorem.txt")
-        assert os.path.isfile("associated_files/lorem.txt")
-
-        assert md5sum_file("associated_files/lorem.txt") == md5sum_file(path)
-
-    def test_remove(self, conservator):
-        # !!! WE ARE IN A CLASS: State is saved from previous test !!!
-        dataset = conservator.datasets.all().first()
-        dataset.remove_associated_file("lorem.txt")
-
-        dataset.populate("file_locker_files")
-        # But now that it has files, it's not null it's an empty list.
-        assert len(dataset.file_locker_files) == 0
+    dataset = conservator.datasets.all().first()
+    dataset.remove_associated_file("lorem.txt")
+    dataset.populate("file_locker_files")
+    assert len(dataset.file_locker_files) == 0
 
 
-class TestFileLockerCollection:
-    @pytest.fixture(scope="class", autouse=True)
-    def init_media(self, conservator, test_data):
-        MEDIA = [
-            # local_path, remote_path, remote_name
-            (test_data / "jpg" / "cat_2.jpg", "/Cats", "My cat.jpg"),
-        ]
-        upload_media(conservator, MEDIA)
+def test_dataset_file_locker(conservator, test_data, tmp_cwd):
+    conservator.collections.create_from_remote_path("/Test")
 
-    def test_file_locker_files_start_null(self, conservator):
-        collection = conservator.collections.all().first()
-        collection.populate("file_locker_files")
-        assert len(collection.file_locker_files) == 0
+    collection = conservator.collections.all().first()
+    collection.populate("file_locker_files")
+    assert len(collection.file_locker_files) == 0
 
-    def test_download_empty(self, conservator, tmp_cwd):
-        collection = conservator.collections.all().first()
-        collection.download_associated_files(".")
+    collection = conservator.collections.all().first()
+    collection.download_associated_files(".")
+    assert os.path.exists("associated_files")
+    assert os.path.isdir("associated_files")
+    assert len(os.listdir("associated_files")) == 0
 
-        assert os.path.exists("associated_files")
-        assert os.path.isdir("associated_files")
-        assert len(os.listdir("associated_files")) == 0
+    path = test_data / "txt" / "lorem.txt"
+    collection = conservator.collections.all().first()
+    collection.upload_associated_file(path)
+    collection.populate("file_locker_files")
+    assert len(collection.file_locker_files) == 1
+    assert collection.file_locker_files[0].name == "lorem.txt"
 
-    def test_upload(self, conservator, test_data):
-        path = test_data / "txt" / "lorem.txt"
-        collection = conservator.collections.all().first()
-        collection.upload_associated_file(path)
+    collection.download_associated_files(".")
+    assert len(os.listdir("associated_files")) == 1
+    assert os.path.exists("associated_files/lorem.txt")
+    assert os.path.isfile("associated_files/lorem.txt")
+    assert md5sum_file("associated_files/lorem.txt") == md5sum_file(path)
 
-        collection.populate("file_locker_files")
-        assert len(collection.file_locker_files) == 1
-        assert collection.file_locker_files[0].name == "lorem.txt"
-
-    def test_download(self, conservator, tmp_cwd, test_data):
-        # !!! WE ARE IN A CLASS: State is saved from previous test !!!
-        path = test_data / "txt" / "lorem.txt"
-        collection = conservator.collections.all().first()
-        collection.download_associated_files(".")
-
-        assert len(os.listdir("associated_files")) == 1
-        assert os.path.exists("associated_files/lorem.txt")
-        assert os.path.isfile("associated_files/lorem.txt")
-
-        assert md5sum_file("associated_files/lorem.txt") == md5sum_file(path)
-
-    def test_remove(self, conservator):
-        # !!! WE ARE IN A CLASS: State is saved from previous test !!!
-        collection = conservator.collections.all().first()
-        collection.remove_associated_file("lorem.txt")
-
-        collection.populate("file_locker_files")
-        # But now that it has files, it's not null it's an empty list.
-        assert len(collection.file_locker_files) == 0
+    collection = conservator.collections.all().first()
+    collection.remove_associated_file("lorem.txt")
+    collection.populate("file_locker_files")
+    assert len(collection.file_locker_files) == 0


### PR DESCRIPTION
Runs same tests for media, dataset, collection

Tests are pretty simple, and work off of each other (not best practice, D: )