### PR TITLE
Add tests for MetadataType

### DIFF
--- a/FLIR/conservator/wrappers/dataset.py
+++ b/FLIR/conservator/wrappers/dataset.py
@@ -68,6 +68,19 @@ class Dataset(QueryableType, FileLockerType, MetadataType):
             dataset_id=self.id,
         )
 
+    @requires_fields("name")
+    def download_metadata(self, path):
+        """
+        Downloads metadata to `path/name.json`,
+        where `name` is the dataset's name.
+        """
+        metadata = self.generate_metadata()
+        json_data = json.loads(metadata)
+        json_file = f"{self.name}.json"
+        json_path = os.path.join(path, json_file)
+        with open(json_path, "w") as file:
+            json.dump(json_data, file, indent=4, separators=(",", ": "))
+
     def get_frames(self, search_text="", fields=None):
         """
         Returns a paginated query for dataset frames within this dataset, filtering

--- a/FLIR/conservator/wrappers/metadata.py
+++ b/FLIR/conservator/wrappers/metadata.py
@@ -50,7 +50,7 @@ class MetadataType(TypeProxy):
             "content_type": content_type,
         }
         result = self._conservator.query(self.metadata_gen_url, **mutation_args)
-        return result.signed_url
+        return result
 
     def _confirm_metadata_upload(self, url):
         """
@@ -84,8 +84,8 @@ class MetadataType(TypeProxy):
             content_type = self.default_file_type
         url = self._generate_metadata_url(file_path, content_type)
         try:
-            self._conservator.files.upload(url=url, local_path=file_path)
+            self._conservator.files.upload(url=url.signed_url, local_path=file_path)
         except FileUploadException as e:
             raise MetadataUploadException from e
-        result = self._confirm_metadata_upload(url)
+        result = self._confirm_metadata_upload(url.url)
         return result

--- a/test/integration/test_metadata.py
+++ b/test/integration/test_metadata.py
@@ -17,10 +17,12 @@ def test_metadata_download_upload_for_media(conservator, test_data, tmp_cwd):
     local_path = test_data / "jpg" / "bicycle_0.jpg"
     media_id = conservator.media.upload(local_path, collection=collection)
     conservator.media.wait_for_processing(media_id)
-    
+
     image = conservator.images.all().first()
     frame = image.get_frame()
-    annotation = AnnotationCreate(labels=["abc", "def"], bounding_box={"x": 1, "y": 2, "w": 3, "h": 4})
+    annotation = AnnotationCreate(
+        labels=["abc", "def"], bounding_box={"x": 1, "y": 2, "w": 3, "h": 4}
+    )
     frame.add_annotation(annotation)
 
     # First download
@@ -50,4 +52,3 @@ def test_metadata_download_upload_for_dataset(conservator, test_data, tmp_cwd):
     # TODO: download_metadata does not work on Dataset: no field metadata
     # Can switch to using generateMetadata, or remove.
     pass
-

--- a/test/integration/test_metadata.py
+++ b/test/integration/test_metadata.py
@@ -1,0 +1,16 @@
+
+class TestMetadataMedia:
+    def test_upload(self, conservator, test_data):
+        pass
+
+    def test_download(self, conservator, tmp_cwd):
+        pass
+
+
+class TestMetadataDataset:
+    def test_upload(self, conservator, test_data):
+        pass
+
+    def test_download(self, conservator, tmp_cwd):
+        pass
+

--- a/test/integration/test_metadata.py
+++ b/test/integration/test_metadata.py
@@ -1,16 +1,53 @@
+import os
+import json
+from time import sleep
 
-class TestMetadataMedia:
-    def test_upload(self, conservator, test_data):
-        pass
+import pytest as pytest
 
-    def test_download(self, conservator, tmp_cwd):
-        pass
+from FLIR.conservator.generated.schema import AnnotationCreate
+
+# Unfortunately, metadata references specific IDs, so
+# can't be hard-coded test data. Also, can't use a class
+# and split download/upload because file system is wiped
+# between tests.
 
 
-class TestMetadataDataset:
-    def test_upload(self, conservator, test_data):
-        pass
+def test_metadata_download_upload_for_media(conservator, test_data, tmp_cwd):
+    collection = conservator.collections.create_from_remote_path("/Some/Collection")
+    local_path = test_data / "jpg" / "bicycle_0.jpg"
+    media_id = conservator.media.upload(local_path, collection=collection)
+    conservator.media.wait_for_processing(media_id)
+    
+    image = conservator.images.all().first()
+    frame = image.get_frame()
+    annotation = AnnotationCreate(labels=["abc", "def"], bounding_box={"x": 1, "y": 2, "w": 3, "h": 4})
+    frame.add_annotation(annotation)
 
-    def test_download(self, conservator, tmp_cwd):
-        pass
+    # First download
+    image.download_metadata(".")
+
+    assert os.path.exists("bicycle_0.json")
+    assert os.path.isfile("bicycle_0.json")
+    with open("bicycle_0.json") as f:
+        local_metadata = json.load(f)
+    assert local_metadata == json.loads(image.metadata)
+
+    # Then, we modify local metadata
+    annotation = local_metadata["videos"][0]["frames"][0]["annotations"][0]
+    local_metadata["videos"][0]["frames"][0]["annotations"].append(annotation)
+    with open("new_metadata.json", "w") as f:
+        json.dump(local_metadata, f)
+
+    # Lastly, upload previous metadata and check it matches.
+    image.upload_metadata("new_metadata.json")
+    sleep(5)  # wait for annotations to be processed
+    image.populate("metadata")
+    assert local_metadata == json.loads(image.metadata)
+
+
+@pytest.mark.skip()
+def test_metadata_download_upload_for_dataset(conservator, test_data, tmp_cwd):
+    # TODO: download_metadata does not work on Dataset: no field metadata
+    # Can switch to using generateMetadata, or remove.
+    pass
 

--- a/test/integration/test_metadata.py
+++ b/test/integration/test_metadata.py
@@ -13,9 +13,8 @@ from FLIR.conservator.generated.schema import AnnotationCreate
 
 
 def test_metadata_download_upload_for_media(conservator, test_data, tmp_cwd):
-    collection = conservator.collections.create_from_remote_path("/Some/Collection")
     local_path = test_data / "jpg" / "bicycle_0.jpg"
-    media_id = conservator.media.upload(local_path, collection=collection)
+    media_id = conservator.media.upload(local_path)
     conservator.media.wait_for_processing(media_id)
 
     image = conservator.images.all().first()
@@ -34,9 +33,22 @@ def test_metadata_download_upload_for_media(conservator, test_data, tmp_cwd):
         local_metadata = json.load(f)
     assert local_metadata == json.loads(image.metadata)
 
+    # Double-check format
+    assert "videos" in local_metadata
+    videos = local_metadata["videos"]
+    assert len(videos) == 1
+    video = videos[0]
+    assert "frames" in video
+    frames = video["frames"]
+    assert len(frames) == 1
+    frame = frames[0]
+    assert "annotations" in frame
+    annotations = frame["annotations"]
+    assert len(annotations) == 1
+    annotation = annotations[0]
+
     # Then, we modify local metadata
-    annotation = local_metadata["videos"][0]["frames"][0]["annotations"][0]
-    local_metadata["videos"][0]["frames"][0]["annotations"].append(annotation)
+    annotations.append(annotation)
     with open("new_metadata.json", "w") as f:
         json.dump(local_metadata, f)
 
@@ -45,10 +57,52 @@ def test_metadata_download_upload_for_media(conservator, test_data, tmp_cwd):
     sleep(5)  # wait for annotations to be processed
     image.populate("metadata")
     assert local_metadata == json.loads(image.metadata)
+    assert len(image.get_annotations()) == 2
 
 
+# TODO: This test will fail because the import-dataset-metadata worker is not running in k8s.
 @pytest.mark.skip()
 def test_metadata_download_upload_for_dataset(conservator, test_data, tmp_cwd):
-    # TODO: download_metadata does not work on Dataset: no field metadata
-    # Can switch to using generateMetadata, or remove.
-    pass
+    dataset = conservator.datasets.create("The Dataset")
+    local_path = test_data / "jpg" / "bicycle_0.jpg"
+    media_id = conservator.media.upload(local_path)
+    conservator.media.wait_for_processing(media_id)
+
+    image = conservator.images.all().first()
+    frame = image.get_frame()
+    annotation = AnnotationCreate(
+        labels=["abc", "def"], bounding_box={"x": 1, "y": 2, "w": 3, "h": 4}
+    )
+    frame.add_annotation(annotation)
+
+    dataset.add_frames([frame])
+
+    dataset.download_metadata(".")
+
+    assert os.path.exists("The Dataset.json")
+    assert os.path.isfile("The Dataset.json")
+    with open("The Dataset.json") as f:
+        local_metadata = json.load(f)
+    assert local_metadata == json.loads(dataset.generate_metadata())
+
+    # Double-check format
+    assert "frames" in local_metadata
+    frames = local_metadata["frames"]
+    assert len(frames) == 1
+    frame = frames[0]
+    assert "annotations" in frame
+    annotations = frame["annotations"]
+    assert len(annotations) == 1
+    annotation = annotations[0]
+
+    # Then, we modify local metadata
+    annotations.append(annotation)
+    with open("new_metadata.json", "w") as f:
+        json.dump(local_metadata, f)
+
+    # Lastly, upload previous metadata and check it matches.
+    dataset.upload_metadata("new_metadata.json")
+    sleep(5)  # wait for annotations to be processed
+    new_metadata = dataset.generate_metadata()
+    assert local_metadata == json.loads(new_metadata)
+    assert len(new_metadata["frames"][0]["annotations"]) == 2


### PR DESCRIPTION
Dataset metadata tests FAIL because the import-dataset-metadata worker is not deployed in a k8s instance. Will ask evan about this. 

Until changed, this test case is skipped.