### PR TITLE
Jenkins release on PyPI

### DIFF
--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -7,10 +7,20 @@ pipeline {
     }
   }
   stages {
+    stage("Set Version") {
+      when {
+        buildingTag()
+      }
+      steps {
+        // When Jenkins builds from a tag, BRANCH_NAME is set to the tag.
+        // We add it to RELEASE-VERSION so version.py finds it.
+        sh "echo $BRANCH_NAME > RELEASE-VERSION"
+      }
+    }
     stage("Install") {
       steps {
-        echo "Setting up..."
         sh "pip install --no-cache-dir -r requirements.txt"
+        sh "python setup.py --version"
         sh "pip install --no-cache-dir ."
       }
     }
@@ -156,9 +166,6 @@ pipeline {
         TWINE_PASSWORD = credentials("test-pypi-conservator-cli")
       }
       steps {
-        // When Jenkins builds from a tag, BRANCH_NAME is set to the tag.
-        // We add it to RELEASE-VERSION so version.py finds it.
-        sh "echo $BRANCH_NAME > RELEASE-VERSION"
         sh "python setup.py --version"
         sh "pip install build twine"
         sh "python -m build"

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -148,9 +148,7 @@ pipeline {
     }
     stage("Release on Test PyPI") {
       when {
-        tag "test-v*"
-        branch "test-release-*"
-        // not { changeRequest() }
+        buildingTag()
       }
       environment {
         TWINE_REPOSITORY = "testpypi"

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -7,16 +7,6 @@ pipeline {
     }
   }
   stages {
-    stage("Set Version") {
-      when {
-        buildingTag()
-      }
-      steps {
-        // When Jenkins builds from a tag, BRANCH_NAME is set to the tag.
-        // We add it to RELEASE-VERSION so version.py finds it.
-        sh "echo $BRANCH_NAME > RELEASE-VERSION"
-      }
-    }
     stage("Install") {
       steps {
         sh "pip install --no-cache-dir -r requirements.txt"

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -156,6 +156,9 @@ pipeline {
         TWINE_PASSWORD = credentials("test-pypi-conservator-cli")
       }
       steps {
+        // When Jenkins builds from a tag, BRANCH_NAME is set to the tag.
+        // We add it to RELEASE-VERSION so version.py finds it.
+        sh "echo $BRANCH_NAME > RELEASE-VERSION"
         sh "python setup.py --version"
         sh "pip install build twine"
         sh "python -m build"

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -146,14 +146,14 @@ pipeline {
         }
       }
     }
-    stage("Release on Test PyPI") {
+    stage("Release on PyPI") {
       when {
         buildingTag()
       }
       environment {
-        TWINE_REPOSITORY = "testpypi"
+        TWINE_REPOSITORY = "pypi"
         TWINE_USERNAME = "__token__"
-        TWINE_PASSWORD = credentials("test-pypi-conservator-cli")
+        TWINE_PASSWORD = credentials("pypi-conservator-cli")
       }
       steps {
         sh "python setup.py --version"

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -146,6 +146,24 @@ pipeline {
         }
       }
     }
+    stage("Release on Test PyPI") {
+      when {
+        tag "test-v*"
+        branch "test-release-*"
+        // not { changeRequest() }
+      }
+      environment {
+        TWINE_REPOSITORY = "testpypi"
+        TWINE_USERNAME = "__token__"
+        TWINE_PASSWORD = credentials("test-pypi-conservator-cli")
+      }
+      steps {
+        sh "python setup.py --version"
+        sh "pip install build twine"
+        sh "python -m build"
+        sh "python -m twine upload dist/*"
+      }
+    }
   }
   post {
     cleanup {

--- a/version.py
+++ b/version.py
@@ -97,7 +97,7 @@ def get_git_version(abbrev=7):
     # First try to get the current version using “git describe”.
 
     version = call_git_describe(abbrev)
-    if is_dirty():
+    if is_dirty() and version is not None:
         version += "-dirty"
 
     # If that doesn't work, fall back on the value that's in

--- a/version.py
+++ b/version.py
@@ -56,18 +56,6 @@ def call_git_describe(abbrev):
         return None
 
 
-def is_dirty():
-    try:
-        p = Popen(
-            ["git", "diff-index", "--name-only", "HEAD"], stdout=PIPE, stderr=PIPE
-        )
-        p.stderr.close()
-        lines = p.stdout.readlines()
-        return len(lines) > 0
-    except:
-        return False
-
-
 def read_release_version():
     try:
         f = open("RELEASE-VERSION", "r")
@@ -97,8 +85,6 @@ def get_git_version(abbrev=7):
     # First try to get the current version using “git describe”.
 
     version = call_git_describe(abbrev)
-    if is_dirty() and version is not None:
-        version += "-dirty"
 
     # If that doesn't work, fall back on the value that's in
     # RELEASE-VERSION.


### PR DESCRIPTION
To release:
```
git checkout main
git tag -a [version] -m "Release [version]"
git push origin [version]
```

Go to jenkins:
- find the new version under the `Tags` tab.
- click `Build`. this runs tests, builds, and pushes to pypi

Verify version is released on [pypi page](https://pypi.org/project/conservator-cli/), and try `pip install conservator-cli` from a new `venv`.

**Note:** 
- Version string must follow [PEP 440](https://www.python.org/dev/peps/pep-0440/). For instance: `1.1.1`, `1.2.34`
- Version tag must be annotation (created with `-a`).
- Tag must be on `main` branch.
