### PR TITLE
Add a basic CLI test as a template for future tests

### DIFF
--- a/test/integration/test_cli.py
+++ b/test/integration/test_cli.py
@@ -1,0 +1,26 @@
+"""
+This tests the *actual* CLI using subprocess
+
+Tests must use the default_conservator fixture, which sets Config.default(),
+as used by the CLI commands.
+"""
+import os
+import subprocess
+from time import sleep
+
+
+def cli(*args):
+    return subprocess.run(
+        ["conservator", *map(str, args)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_whoami(default_conservator):
+    user = default_conservator.get_user()
+
+    p = cli("whoami")
+
+    assert p.returncode == 0
+    assert user.email in p.stdout.decode()


### PR DESCRIPTION
I'm not going to add any integration tests for CLI commands at this time. If something breaks, a bug is found, or we make changes to any commands, we should add tests.

This PR just adds a file/template for CLI tests in the future