### PR TITLE
Avoid creating Conservator until needed in Click context

### DIFF
--- a/FLIR/conservator/cli/__init__.py
+++ b/FLIR/conservator/cli/__init__.py
@@ -28,7 +28,7 @@ import logging
 )
 @click.option(
     "--config",
-    default=None,
+    default="default",
     help="Conservator config name, use default credentials if not specified",
 )
 def main(log, config):
@@ -41,16 +41,15 @@ def main(log, config):
     }
     logging.basicConfig(level=levels[log])
 
-    conservator = Conservator.create(config_name=config)
     ctx = click.get_current_context()
     ctx.ensure_object(dict)
-    ctx.obj["conservator"] = conservator
+    ctx.obj["config_name"] = config
 
 
 @main.command(help="Print information on the current user")
 def whoami():
     ctx_obj = click.get_current_context().obj
-    conservator = ctx_obj["conservator"]
+    conservator = Conservator.create(ctx_obj["config_name"])
     user = conservator.get_user()
     click.echo(to_clean_string(user))
 

--- a/FLIR/conservator/cli/cvc.py
+++ b/FLIR/conservator/cli/cvc.py
@@ -1,5 +1,4 @@
 import functools
-import os
 import subprocess
 
 import click
@@ -7,7 +6,6 @@ import logging
 
 from click import get_current_context
 
-from FLIR.conservator.config import Config
 from FLIR.conservator.conservator import Conservator
 from FLIR.conservator.local_dataset import LocalDataset
 
@@ -17,7 +15,7 @@ def pass_valid_local_dataset(func):
     def wrapper(*args, **kwargs):
         ctx_obj = get_current_context().obj
         path = ctx_obj["cvc_local_path"]
-        conservator = ctx_obj["conservator"]
+        conservator = Conservator.create(ctx_obj["config_name"])
         # raises InvalidLocalDatasetPath if the path does not point to a
         # valid LocalDataset (defined as a directory containing index.json).
         local_dataset = LocalDataset(conservator, path)
@@ -36,7 +34,7 @@ def pass_valid_local_dataset(func):
 )
 @click.option(
     "--config",
-    default=None,
+    default="default",
     help="Conservator config name, use default credentials if not specified",
 )
 @click.option(
@@ -53,9 +51,8 @@ def main(ctx, log, path, config):
     }
     logging.basicConfig(level=levels[log])
 
-    conservator = Conservator.create(config_name=config)
     ctx.ensure_object(dict)
-    ctx.obj["conservator"] = conservator
+    ctx.obj["config_name"] = config
     ctx.obj["cvc_local_path"] = path
 
 
@@ -73,7 +70,7 @@ def main(ctx, log, path, config):
 )
 @click.pass_context
 def clone(ctx, identifier, path, checkout):
-    conservator = ctx.obj["conservator"]
+    conservator = Conservator.create(ctx.obj["config_name"])
     dataset = conservator.datasets.from_string(identifier)
     cloned = LocalDataset.clone(dataset, path)
     if checkout is not None:

--- a/FLIR/conservator/cli/interactive.py
+++ b/FLIR/conservator/cli/interactive.py
@@ -400,7 +400,7 @@ def run_shell_command(command):
 def interactive():
     global conservator
     ctx_obj = click.get_current_context().obj
-    conservator = ctx_obj["conservator"]
+    conservator = Conservator.create(ctx_obj["config_name"])
 
     click.secho(
         """This is an interactive conservator "shell" that simulates the directory\n"""

--- a/FLIR/conservator/cli/managers.py
+++ b/FLIR/conservator/cli/managers.py
@@ -1,6 +1,7 @@
 import click
 import functools
 
+from FLIR.conservator.conservator import Conservator
 from FLIR.conservator.fields_request import FieldsRequest
 from FLIR.conservator.managers import (
     SearchableTypeManager,
@@ -43,7 +44,7 @@ def fields_request(func):
 def get_manager_command(type_manager, sgqlc_type, name):
     def get_instance():
         ctx_obj = click.get_current_context().obj
-        conservator = ctx_obj["conservator"]
+        conservator = Conservator.create(ctx_obj["config_name"])
         return type_manager(conservator)
 
     @click.group(name=name, help=f"View or manage {name}")
@@ -417,7 +418,7 @@ def get_manager_command(type_manager, sgqlc_type, name):
         )
         def upload(localpath, remote_collection, remote_name, create_collections):
             ctx_obj = click.get_current_context().obj
-            conservator = ctx_obj["conservator"]
+            conservator = Conservator.create(ctx_obj["config_name"])
             if create_collections:
                 collection = conservator.collections.from_remote_path(
                     path=remote_collection, make_if_no_exist=True, fields="id"


### PR DESCRIPTION
This fixes some issues when running commands without a valid config (such when creating your first config).

Conservator will only be created from config_name (or `default`) when it will be needed.

In short, click ctx now holds config_name, not conservator instance.