### PR TITLE
Adjust tests for fixed FileLocker

### DIFF
--- a/FLIR/conservator/wrappers/file_locker.py
+++ b/FLIR/conservator/wrappers/file_locker.py
@@ -60,10 +60,6 @@ class FileLockerType(TypeProxy):
         os.makedirs(path, exist_ok=True)
         downloads = []
 
-        if self.file_locker_files is None:
-            # Sometimes it can be null?
-            return
-
         for file in self.file_locker_files:
             local_path = os.path.join(path, file.name)
             download = DownloadRequest(url=file.url, local_path=local_path)

--- a/test/integration/test_file_locker.py
+++ b/test/integration/test_file_locker.py
@@ -1,8 +1,6 @@
 import os
-import pytest as pytest
 
 from FLIR.conservator.util import md5sum_file
-from conftest import upload_media
 
 
 def test_media_file_locker(conservator, test_data, tmp_cwd):
@@ -12,11 +10,7 @@ def test_media_file_locker(conservator, test_data, tmp_cwd):
 
     image = conservator.images.all().first()
     image.populate("file_locker_files")
-    # For some reason, it starts as null.
-    # This behavior is unique to Image/Video.
-    # JIRA Ticket CON-1472 is tracking this discrepancy.
-    assert image.file_locker_files is None
-    # assert len(image.file_locker_files) == 0
+    assert len(image.file_locker_files) == 0
 
     image.download_associated_files(".")
     assert os.path.exists("associated_files")


### PR DESCRIPTION
With  https://github.com/FLIR/flirconservator/pull/2187/ , FileLocker will never be null

This PR updates tests and removes a `None` check.

Of course, this PR will fail to pass tests until that PR reaches `:prod`.
