### PR TITLE
Fix exception raised from conservator --version

### DIFF
--- a/FLIR/conservator/cli/__init__.py
+++ b/FLIR/conservator/cli/__init__.py
@@ -30,7 +30,7 @@ import logging
     default="default",
     help="Conservator config name, use default credentials if not specified",
 )
-@click.version_option(prog_name="conservator-cli")
+@click.version_option(prog_name="conservator-cli", package_name="conservator-cli")
 def main(log, config):
     levels = {
         "DEBUG": logging.DEBUG,

--- a/FLIR/conservator/cli/cvc.py
+++ b/FLIR/conservator/cli/cvc.py
@@ -40,7 +40,7 @@ def pass_valid_local_dataset(func):
 @click.option(
     "-p", "--path", default=".", help="Path to dataset, defaults to current directory"
 )
-@click.version_option(prog_name="conservator-cli")
+@click.version_option(prog_name="conservator-cli", package_name="conservator-cli")
 @click.pass_context
 def main(ctx, log, path, config):
     levels = {


### PR DESCRIPTION
When attempting to detect the package version, click's version_option()
code was hitting an exception:

    RuntimeError: 'FLIR' is not installed. Try passing 'package_name' instead.

Pass `package_name` as suggested.