### PR TITLE
set requirements to ensure click >= 8.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 wheel
 sphinx
 sgqlc
-click >= 7
+click >= 8
 tqdm
 pytest
 requests

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open("README.md", "r") as fh:
 # in requirements.txt instead.
 INSTALL_REQUIRES = [
     "sgqlc",
-    "click >= 7",
+    "click >= 8",
     "tqdm",
     "requests",
     "Pillow",


### PR DESCRIPTION
Pretty simple fix to ensure that click is at least version 8.0.0  

tested it to make sure that error does not show up anymore after ensuring click is at least 8.0.0  

Link to jira ticket: https://jiracommercial.flir.com/browse/CON-1686