### PR TITLE
Add associated frame methods to dataset objects

### DIFF
--- a/test/integration/test_dataset.py
+++ b/test/integration/test_dataset.py
@@ -71,6 +71,32 @@ def test_add_get_frames(conservator, test_data):
     assert dataset_frames[0].frame_id == frame.id
 
 
+def test_add_get_frames_reversed(conservator, test_data):
+    local_path1 = test_data / "png" / "flight_0.png"
+    local_path2 = test_data / "png" / "flight_1.png"
+    media_ids = [conservator.media.upload(local_path1)]
+    media_ids.append(conservator.media.upload(local_path2))
+    for media_id in media_ids:
+        conservator.media.wait_for_processing(media_id)
+    images = list(conservator.images.all())
+    frames = [image.get_frame() for image in images]
+
+    dataset = conservator.datasets.create("Test dataset")
+    dataset.add_frames(frames)
+
+    dataset.populate("frame_count")
+    assert dataset.frame_count == 2
+
+    dataset_frames = list(dataset.get_frames())
+    assert len(dataset_frames) == 2
+    reversed_frames = list(dataset.get_frames_reversed(fields=["dataset_frames.id"]))
+    assert len(reversed_frames) == 2
+
+    frame_ids = [frm.id for frm in dataset_frames]
+    compare_frame_ids = [frm.id for frm in reversed(reversed_frames)]
+    assert compare_frame_ids == frame_ids
+
+
 def test_associate_frames(conservator, test_data):
     local_path1 = test_data / "png" / "flight_0.png"
     local_path2 = test_data / "png" / "flight_1.png"

--- a/test/integration/test_dataset.py
+++ b/test/integration/test_dataset.py
@@ -2,6 +2,8 @@ import json
 import pytest
 import time
 
+from FLIR.conservator.generated.schema import AddAssociatedFrameInput
+
 
 def test_create(conservator):
     dataset = conservator.datasets.create("My Dataset")
@@ -67,6 +69,39 @@ def test_add_get_frames(conservator, test_data):
     dataset_frames = list(dataset.get_frames())
     assert len(dataset_frames) == 1
     assert dataset_frames[0].frame_id == frame.id
+
+
+def test_associate_frames(conservator, test_data):
+    local_path1 = test_data / "png" / "flight_0.png"
+    local_path2 = test_data / "png" / "flight_1.png"
+    media_ids = [conservator.media.upload(local_path1)]
+    media_ids.append(conservator.media.upload(local_path2))
+    for media_id in media_ids:
+        conservator.media.wait_for_processing(media_id)
+    images = list(conservator.images.all())
+    frames = [image.get_frame() for image in images]
+
+    dataset1 = conservator.datasets.create("Test dataset1")
+    dataset1.add_frames([frames[0]])
+    dataset2 = conservator.datasets.create("Test dataset2")
+    dataset2.add_frames([frames[1]])
+
+    dset1_frames = list(dataset1.get_frames(fields="dataset_frames.id"))
+    dset2_frames = list(dataset2.get_frames(fields="dataset_frames.id"))
+
+    associate_frame_input = AddAssociatedFrameInput(
+        dataset_frame_id=dset2_frames[0].id, spectrum="Thermal"
+    )
+    dataset1.associate_frame(dset1_frames[0].id, associate_frame_input)
+
+    dataset_frames = list(
+        dataset1.get_frames(
+            fields=["dataset_frames.id", "dataset_frames.associated_frames"]
+        )
+    )
+    assert len(dataset_frames) == 1
+    assert len(dataset_frames[0].associated_frames) == 1
+    assert dataset_frames[0].associated_frames[0].spectrum == "Thermal"
 
 
 def test_commit_and_history(conservator, test_data):


### PR DESCRIPTION
Datasets now have 3 new methods:

* get_frames_reversed() - Reverses the get_frames() iterator in order to
  find the newest frames first, which speeds up the search for new
  dataset IDs that have just been added to the dataset.  Dataset frames
  are always returned in same order in which they were added.

* associate_frame() - Associates a dataset frame ID with a video frame
  or dataset frame ID specified in an AddAssociatedFrameInput object.

* add_frames_with_associations() - Adds new frames to a dataset, then
  associates the new dataset frame IDs with other video or dataset frame
  IDs using a table that maps source video frame IDs to lists of
  AddAssociatedFrameInput objects.

Add new PaginatedQuery parameters `reverse` and `total_unpack_field` to
iterate through API results in reverse order.