### PR TITLE
Remove trailing slashes from collection paths

### DIFF
--- a/FLIR/conservator/wrappers/collection.py
+++ b/FLIR/conservator/wrappers/collection.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 from FLIR.conservator.fields_request import FieldsRequest
 from FLIR.conservator.file_transfers import DownloadRequest
@@ -136,17 +137,23 @@ class Collection(QueryableType, FileLockerType):
         If `make_if_no_exist` is `True`, then collection(s) will be created to
         reach that path if it doesn't exist.
         """
+        # Remove repeated '/' characters.
+        clean_path = re.sub("/+", "/", path)
+
         if not path.startswith("/"):
-            path = "/" + path
+            clean_path = "/" + path
+
+        if clean_path.endswith("/"):
+            clean_path = clean_path[:-1]
 
         collection = conservator.query(
-            Query.collection_by_path, path=path, fields=fields
+            Query.collection_by_path, path=clean_path, fields=fields
         )
         if collection is None:
             if make_if_no_exist:
-                return cls.create_from_remote_path(conservator, path, fields)
+                return cls.create_from_remote_path(conservator, clean_path, fields)
             else:
-                raise InvalidRemotePathException(path)
+                raise InvalidRemotePathException(clean_path)
         return collection
 
     def recursively_get_children(self, include_self=False, fields=None):


### PR DESCRIPTION
In the Collection method `from_remote_path()`, strip off any trailing slash before sending the path to the `collectionByPath` API call.  The API call will fail and the user will not receive clear feedback about what caused the failure otherwise.