### PR TITLE
Support remove frames

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -60,18 +60,21 @@ def conservator_domain(using_kubernetes):
 def mongo_client(using_kubernetes, conservator_domain):
     if using_kubernetes:
         mongo_pod_name = get_mongo_pod_name()
-        # Port forward 27030 in the background...
+        # Port forward 27017 in the background...
+        # note that it should be the standard mongo port,
+        # anything else causes problems if mongodb server
+        # has been configured with replica set
         port_forward_proc = subprocess.Popen(
             [
                 "kubectl",
                 "--insecure-skip-tls-verify",
                 "port-forward",
-                mongo_pod_name,
-                f"27030:27017",
+                "service/conservator-mongo",
+                f"27017:27017",
             ]
         )
         # Because of the port forward process, mongo will be accessible on localhost
-        yield pymongo.MongoClient(f"mongodb://localhost:27030/")
+        yield pymongo.MongoClient(f"mongodb://localhost:27017/")
         port_forward_proc.terminate()
     else:  # Using docker
         domain = subprocess.getoutput(

--- a/test/integration/test_dataset.py
+++ b/test/integration/test_dataset.py
@@ -158,6 +158,37 @@ def test_add_with_associated_frames(conservator, test_data):
     assert dataset_frames[0].associated_frames[0].spectrum == "Thermal"
 
 
+def test_remove_frames(conservator, test_data):
+    local_path = test_data / "png" / "flight_0.png"
+    media_id = conservator.media.upload(local_path)
+    conservator.media.wait_for_processing(media_id)
+    image = conservator.images.all().first()
+    frame = image.get_frame()
+    dataset = conservator.datasets.create("Test dataset")
+
+    # test deleting by dataset frame id
+    dataset.add_frames([frame])
+
+    dataset_frames = list(dataset.get_frames())
+    assert len(dataset_frames) == 1
+
+    dataset.remove_frames(dataset_frames)
+
+    dataset_frames = list(dataset.get_frames())
+    assert len(dataset_frames) == 0
+
+    # test deleting by video frame id
+    dataset.add_frames([frame])
+
+    dataset_frames = list(dataset.get_frames())
+    assert len(dataset_frames) == 1
+
+    dataset.remove_frames([frame])
+
+    dataset_frames = list(dataset.get_frames())
+    assert len(dataset_frames) == 0
+
+
 def test_commit_and_history(conservator, test_data):
     local_path = test_data / "png" / "flight_0.png"
     media_id = conservator.media.upload(local_path)


### PR DESCRIPTION
Implement Dataset object method to remove frames

remove_frames() can take a list of either Frame or DatasetFrame
objects and remove the corresponding frames. There are 2 separate
mutations in the server API, one for Frame and another for DatasetFrame,
so the type of wrapper object is used to decide which mutation to use.

Addresses #280 