### PR TITLE
remove race codition from cvc integration tests

### DIFF
--- a/FLIR/conservator/file_transfers.py
+++ b/FLIR/conservator/file_transfers.py
@@ -189,7 +189,7 @@ class ConservatorFileTransfers:
                     )
                     time.sleep(retries)  # Timeout increases per retry.
                     continue
-            raise FileUploadException(url)
+            raise FileUploadException(f"url={url} response={response}))")
         logger.info(f"Completed upload of '{path}'")
         return response
 

--- a/test/integration/test_cvc.py
+++ b/test/integration/test_cvc.py
@@ -79,8 +79,18 @@ def test_cvc_clone_download(default_conservator, tmp_cwd, test_data):
     video = default_conservator.get_media_instance_from_id(media_id)
     video.populate("frames")
     dataset.add_frames(video.frames)
-    dataset.commit("Add video frames to dataset")
-    sleep(5)
+    commit_message = "Add video frames to dataset"
+    dataset.commit(commit_message)
+
+    # wait up to 30 sec for commit to appear.
+    history = []
+    for i in range(30):
+        sleep(1)
+        history = dataset.get_commit_history(fields="short_message")
+        if history[0].short_message == commit_message:
+            break
+    assert history
+    assert history[0].short_message == commit_message
 
     cvc("clone", dataset.id)
     os.chdir("My dataset")


### PR DESCRIPTION
test_cvc_clone_download() was waiting a fixed amount between
using dataset API to commit changes and cloning that same dataset.
The test would fail if the dataset commit took longer than
expected to complete. Instead of bumping up the sleep time,
making tests slower than needed in most cases, watch for the commit
to appear in the dataset's commit history each second up to 30 seconds.

Also add response code to FileUploadException info, which is thrown
in the case of a failed media upload attempt. For instance, now you can tell
whether the failure was 502 Bad Gateway or 413 Request Entity Too Large