### PR TITLE
informative user-agent header

### DIFF
--- a/FLIR/conservator/connection.py
+++ b/FLIR/conservator/connection.py
@@ -1,6 +1,8 @@
 import re
 import urllib.parse
 import logging
+import platform
+import sys
 
 import requests
 from sgqlc.endpoint.http import HTTPEndpoint
@@ -9,6 +11,7 @@ from sgqlc.operation import Operation
 from FLIR.conservator.fields_manager import FieldsManager
 from FLIR.conservator.fields_request import FieldsRequest
 from FLIR.conservator.generated.schema import schema, Query
+from FLIR.conservator.version import version as cli_ver
 
 __all__ = [
     "ConservatorMalformedQueryException",
@@ -59,8 +62,16 @@ class ConservatorConnection:
         self.config = config
         self.email = None
         self.graphql_url = ConservatorConnection.to_graphql_url(config.url)
+
+        python_ver = sys.version.split()[0]
+        os_name = platform.system()
+        os_ver = platform.release()
+        agent_string = (
+            f"conservator-cli/{cli_ver} Python/{python_ver} {os_name}/{os_ver}"
+        )
         headers = {
             "authorization": config.key,
+            "User-Agent": agent_string,
         }
         self.endpoint = HTTPEndpoint(self.graphql_url, base_headers=headers)
         self.fields_manager = FieldsManager()


### PR DESCRIPTION
Send user agent header to server containing following info:
conservator-cli/$CLI_VERSION Python/$PYTHON_VERSION $OS_TYPE/$OS_VERSION

Example:

     POST /graphql HTTP/1.1
     Accept-Encoding: identity
     User-Agent: conservator-cli/2.3.0-3+g90f0f2d Python/3.6.9 Linux/4.15.0-147-generic
     ...

**File Changes:**

`FLIR/conservator/connection.py`
- add User-Agent string to http request headers

[[JIRA Task](https://jiracommercial.flir.com/browse/CON-2491)]
