### PR TITLE
Con 2527 20220411 sipport create dataset frame api

### DIFF
--- a/FLIR/conservator/fields_manager.py
+++ b/FLIR/conservator/fields_manager.py
@@ -165,7 +165,7 @@ class FieldsManager:
             selector.url()
             selector.md5()
             selector.state()
-            selector.frames_count()
+            selector.frame_count()
             selector.annotations_count()
             selector.human_annotations_count()
             selector.name()

--- a/FLIR/conservator/generated/generate.sh
+++ b/FLIR/conservator/generated/generate.sh
@@ -7,7 +7,6 @@ read -p "API Key: " key
 read -p "Endpoint URL (include /graphql): " url
 
 python3 -m sgqlc.introspection \
-  --exclude-deprecated \
   --exclude-description \
   -H "authorization: ${key}" \
   ${url} \

--- a/FLIR/conservator/generated/schema.py
+++ b/FLIR/conservator/generated/schema.py
@@ -1337,6 +1337,7 @@ class Annotation(sgqlc.types.Type):
     __field_names__ = (
         "id",
         "target_id",
+        "label",
         "labels",
         "label_id",
         "bounding_box",
@@ -1350,6 +1351,9 @@ class Annotation(sgqlc.types.Type):
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(GraphqlID), graphql_name="id")
     target_id = sgqlc.types.Field(String, graphql_name="targetId")
+    label = sgqlc.types.Field(
+        sgqlc.types.non_null(AllowedLabelCharacters), graphql_name="label"
+    )
     labels = sgqlc.types.Field(
         sgqlc.types.non_null(
             sgqlc.types.list_of(sgqlc.types.non_null(AllowedLabelCharacters))
@@ -2010,6 +2014,7 @@ class DatasetAnnotation(sgqlc.types.Type):
     __field_names__ = (
         "id",
         "target_id",
+        "label",
         "labels",
         "label_id",
         "bounding_box",
@@ -2023,6 +2028,9 @@ class DatasetAnnotation(sgqlc.types.Type):
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(GraphqlID), graphql_name="id")
     target_id = sgqlc.types.Field(String, graphql_name="targetId")
+    label = sgqlc.types.Field(
+        sgqlc.types.non_null(AllowedLabelCharacters), graphql_name="label"
+    )
     labels = sgqlc.types.Field(
         sgqlc.types.non_null(
             sgqlc.types.list_of(sgqlc.types.non_null(AllowedLabelCharacters))
@@ -2809,6 +2817,7 @@ class Image(sgqlc.types.Type):
         "object_detect_batches_total",
         "object_detect_batches_done",
         "spectrum",
+        "asset_type",
         "object_detect_details",
         "inherited_acl",
         "readme",
@@ -2921,6 +2930,7 @@ class Image(sgqlc.types.Type):
         Int, graphql_name="objectDetectBatchesDone"
     )
     spectrum = sgqlc.types.Field(String, graphql_name="spectrum")
+    asset_type = sgqlc.types.Field(String, graphql_name="assetType")
     object_detect_details = sgqlc.types.Field(
         sgqlc.types.non_null(sgqlc.types.list_of("ObjectDetectDetails")),
         graphql_name="objectDetectDetails",
@@ -3089,6 +3099,7 @@ class Mutation(sgqlc.types.Type):
         "add_frames_to_dataset",
         "remove_frames_from_dataset",
         "remove_frames_from_dataset_by_ids",
+        "create_dataset_by_frame_filter",
         "update_dataset_acl",
         "add_dataset_acl",
         "remove_dataset_acl",
@@ -3901,6 +3912,30 @@ class Mutation(sgqlc.types.Type):
                     sgqlc.types.Arg(
                         sgqlc.types.non_null(RemoveFramesFromDatasetByIdsInput),
                         graphql_name="input",
+                        default=None,
+                    ),
+                ),
+            )
+        ),
+    )
+    create_dataset_by_frame_filter = sgqlc.types.Field(
+        sgqlc.types.non_null(Dataset),
+        graphql_name="createDatasetByFrameFilter",
+        args=sgqlc.types.ArgDict(
+            (
+                (
+                    "name",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(StringLowerCase),
+                        graphql_name="name",
+                        default=None,
+                    ),
+                ),
+                (
+                    "filter",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(FrameFilter),
+                        graphql_name="filter",
                         default=None,
                     ),
                 ),
@@ -9597,6 +9632,8 @@ class Video(sgqlc.types.Type):
         "uploaded_by",
         "uploaded_by_name",
         "uploaded_by_email",
+        "frames",
+        "frames_count",
         "frame_count",
         "annotations_count",
         "human_annotations_count",
@@ -9615,6 +9652,7 @@ class Video(sgqlc.types.Type):
         "annotation_import_state",
         "annotation_import_state_modified_at",
         "highest_target_id",
+        "custom_metadata",
         "collections",
         "segments",
         "datasets",
@@ -9624,6 +9662,7 @@ class Video(sgqlc.types.Type):
         "object_detect_batches_total",
         "object_detect_batches_done",
         "spectrum",
+        "asset_type",
         "is_favorite",
         "favorite_count",
         "object_detect_details",
@@ -9682,6 +9721,24 @@ class Video(sgqlc.types.Type):
     uploaded_by = sgqlc.types.Field(String, graphql_name="uploadedBy")
     uploaded_by_name = sgqlc.types.Field(String, graphql_name="uploadedByName")
     uploaded_by_email = sgqlc.types.Field(String, graphql_name="uploadedByEmail")
+    frames = sgqlc.types.Field(
+        sgqlc.types.list_of(Frame),
+        graphql_name="frames",
+        args=sgqlc.types.ArgDict(
+            (
+                ("id", sgqlc.types.Arg(GraphqlID, graphql_name="id", default=None)),
+                (
+                    "frame_index",
+                    sgqlc.types.Arg(Int, graphql_name="frameIndex", default=None),
+                ),
+                (
+                    "start_frame_index",
+                    sgqlc.types.Arg(Int, graphql_name="startFrameIndex", default=None),
+                ),
+            )
+        ),
+    )
+    frames_count = sgqlc.types.Field(Int, graphql_name="framesCount")
     frame_count = sgqlc.types.Field(Int, graphql_name="frameCount")
     annotations_count = sgqlc.types.Field(Int, graphql_name="annotationsCount")
     human_annotations_count = sgqlc.types.Field(
@@ -9710,6 +9767,7 @@ class Video(sgqlc.types.Type):
         Date, graphql_name="annotationImportStateModifiedAt"
     )
     highest_target_id = sgqlc.types.Field(Int, graphql_name="highestTargetId")
+    custom_metadata = sgqlc.types.Field(String, graphql_name="customMetadata")
     collections = sgqlc.types.Field(
         sgqlc.types.non_null(sgqlc.types.list_of(GraphqlID)), graphql_name="collections"
     )
@@ -9727,6 +9785,7 @@ class Video(sgqlc.types.Type):
         Int, graphql_name="objectDetectBatchesDone"
     )
     spectrum = sgqlc.types.Field(String, graphql_name="spectrum")
+    asset_type = sgqlc.types.Field(String, graphql_name="assetType")
     is_favorite = sgqlc.types.Field(
         sgqlc.types.non_null(Boolean), graphql_name="isFavorite"
     )

--- a/FLIR/conservator/generated/schema.py
+++ b/FLIR/conservator/generated/schema.py
@@ -7951,6 +7951,7 @@ class Query(sgqlc.types.Type):
         "project",
         "ntk_configs",
         "assets_by_md5s",
+        "does_md5_exist",
     )
     annotations_by_video_id = sgqlc.types.Field(
         sgqlc.types.list_of(Annotation),
@@ -9392,6 +9393,22 @@ class Query(sgqlc.types.Type):
                             sgqlc.types.list_of(sgqlc.types.non_null(Md5String))
                         ),
                         graphql_name="md5s",
+                        default=None,
+                    ),
+                ),
+            )
+        ),
+    )
+    does_md5_exist = sgqlc.types.Field(
+        sgqlc.types.non_null(Boolean),
+        graphql_name="doesMd5Exist",
+        args=sgqlc.types.ArgDict(
+            (
+                (
+                    "md5",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(Md5String),
+                        graphql_name="md5",
                         default=None,
                     ),
                 ),

--- a/FLIR/conservator/generated/schema.py
+++ b/FLIR/conservator/generated/schema.py
@@ -497,6 +497,76 @@ class CreateDatasetAnnotationInput(sgqlc.types.Input):
     qa_status_note = sgqlc.types.Field(String, graphql_name="qaStatusNote")
 
 
+class CreateDatasetFrameInput(sgqlc.types.Input):
+    __schema__ = schema
+    __field_names__ = (
+        "id",
+        "frame_id",
+        "video_id",
+        "frame_index",
+        "preview_width",
+        "preview_height",
+        "width",
+        "height",
+        "is_empty",
+        "is_flagged",
+        "is_itar",
+        "description",
+        "location",
+        "tags",
+        "spectrum",
+        "md5",
+        "file_size",
+        "analytics_md5",
+        "preview_md5",
+        "preview_file_size",
+        "custom_metadata",
+        "labelbox_data_row_id",
+        "qa_status",
+        "qa_status_note",
+        "associated_frames",
+    )
+    id = sgqlc.types.Field(GraphqlID, graphql_name="id")
+    frame_id = sgqlc.types.Field(GraphqlID, graphql_name="frameId")
+    video_id = sgqlc.types.Field(GraphqlID, graphql_name="videoId")
+    frame_index = sgqlc.types.Field(
+        sgqlc.types.non_null(Int), graphql_name="frameIndex"
+    )
+    preview_width = sgqlc.types.Field(
+        sgqlc.types.non_null(Int), graphql_name="previewWidth"
+    )
+    preview_height = sgqlc.types.Field(
+        sgqlc.types.non_null(Int), graphql_name="previewHeight"
+    )
+    width = sgqlc.types.Field(sgqlc.types.non_null(Int), graphql_name="width")
+    height = sgqlc.types.Field(sgqlc.types.non_null(Int), graphql_name="height")
+    is_empty = sgqlc.types.Field(Boolean, graphql_name="isEmpty")
+    is_flagged = sgqlc.types.Field(Boolean, graphql_name="isFlagged")
+    is_itar = sgqlc.types.Field(Boolean, graphql_name="isItar")
+    description = sgqlc.types.Field(String, graphql_name="description")
+    location = sgqlc.types.Field(String, graphql_name="location")
+    tags = sgqlc.types.Field(
+        sgqlc.types.list_of(sgqlc.types.non_null(StringLowerCase)), graphql_name="tags"
+    )
+    spectrum = sgqlc.types.Field(Spectrum, graphql_name="spectrum")
+    md5 = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name="md5")
+    file_size = sgqlc.types.Field(sgqlc.types.non_null(Float), graphql_name="fileSize")
+    analytics_md5 = sgqlc.types.Field(String, graphql_name="analyticsMd5")
+    preview_md5 = sgqlc.types.Field(
+        sgqlc.types.non_null(String), graphql_name="previewMd5"
+    )
+    preview_file_size = sgqlc.types.Field(
+        sgqlc.types.non_null(Float), graphql_name="previewFileSize"
+    )
+    custom_metadata = sgqlc.types.Field(String, graphql_name="customMetadata")
+    labelbox_data_row_id = sgqlc.types.Field(String, graphql_name="labelboxDataRowId")
+    qa_status = sgqlc.types.Field(String, graphql_name="qaStatus")
+    qa_status_note = sgqlc.types.Field(String, graphql_name="qaStatusNote")
+    associated_frames = sgqlc.types.Field(
+        sgqlc.types.list_of(AddAssociatedFrameInput), graphql_name="associatedFrames"
+    )
+
+
 class CreateDatasetInput(sgqlc.types.Input):
     __schema__ = schema
     __field_names__ = ("id", "name", "collection_ids")
@@ -509,10 +579,19 @@ class CreateDatasetInput(sgqlc.types.Input):
 
 class CreateGroupInput(sgqlc.types.Input):
     __schema__ = schema
-    __field_names__ = ("name", "member_ids")
+    __field_names__ = (
+        "name",
+        "member_ids",
+        "notes",
+        "conservator_insights_license_key",
+    )
     name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name="name")
     member_ids = sgqlc.types.Field(
-        sgqlc.types.non_null(sgqlc.types.list_of(GraphqlID)), graphql_name="memberIds"
+        sgqlc.types.list_of(GraphqlID), graphql_name="memberIds"
+    )
+    notes = sgqlc.types.Field(String, graphql_name="notes")
+    conservator_insights_license_key = sgqlc.types.Field(
+        String, graphql_name="conservatorInsightsLicenseKey"
     )
 
 
@@ -856,6 +935,7 @@ class MetadataInput(sgqlc.types.Input):
         "asset_type",
         "is_itar",
         "attached_label_set_ids",
+        "allow_annotations_outside_frame",
     )
     owner = sgqlc.types.Field(GraphqlID, graphql_name="owner")
     name = sgqlc.types.Field(String, graphql_name="name")
@@ -869,6 +949,9 @@ class MetadataInput(sgqlc.types.Input):
     is_itar = sgqlc.types.Field(Boolean, graphql_name="isItar")
     attached_label_set_ids = sgqlc.types.Field(
         sgqlc.types.list_of(GraphqlID), graphql_name="attachedLabelSetIds"
+    )
+    allow_annotations_outside_frame = sgqlc.types.Field(
+        Boolean, graphql_name="allowAnnotationsOutsideFrame"
     )
 
 
@@ -1105,6 +1188,7 @@ class UpdateDatasetInput(sgqlc.types.Input):
         "tags",
         "attached_label_set_ids",
         "description",
+        "allow_annotations_outside_frame",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(GraphqlID), graphql_name="id")
     owner = sgqlc.types.Field(GraphqlID, graphql_name="owner")
@@ -1118,6 +1202,9 @@ class UpdateDatasetInput(sgqlc.types.Input):
         sgqlc.types.list_of(GraphqlID), graphql_name="attachedLabelSetIds"
     )
     description = sgqlc.types.Field(String, graphql_name="description")
+    allow_annotations_outside_frame = sgqlc.types.Field(
+        Boolean, graphql_name="allowAnnotationsOutsideFrame"
+    )
 
 
 class UpdateDatasetQaStatusNoteInput(sgqlc.types.Input):
@@ -1129,13 +1216,23 @@ class UpdateDatasetQaStatusNoteInput(sgqlc.types.Input):
 
 class UpdateGroupInput(sgqlc.types.Input):
     __schema__ = schema
-    __field_names__ = ("group_id", "name", "member_ids")
+    __field_names__ = (
+        "group_id",
+        "name",
+        "member_ids",
+        "notes",
+        "conservator_insights_license_key",
+    )
     group_id = sgqlc.types.Field(
         sgqlc.types.non_null(GraphqlID), graphql_name="groupId"
     )
     name = sgqlc.types.Field(String, graphql_name="name")
     member_ids = sgqlc.types.Field(
         sgqlc.types.list_of(sgqlc.types.non_null(GraphqlID)), graphql_name="memberIds"
+    )
+    notes = sgqlc.types.Field(String, graphql_name="notes")
+    conservator_insights_license_key = sgqlc.types.Field(
+        String, graphql_name="conservatorInsightsLicenseKey"
     )
 
 
@@ -1432,6 +1529,7 @@ class Collection(sgqlc.types.Type):
         "sqa_run_status_message",
         "sqa_run_error_message",
         "recalculate_stats_state",
+        "recalculate_stats_error",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(GraphqlID), graphql_name="id")
     parent_id = sgqlc.types.Field(GraphqlID, graphql_name="parentId")
@@ -1512,6 +1610,9 @@ class Collection(sgqlc.types.Type):
     sqa_run_error_message = sgqlc.types.Field(String, graphql_name="sqaRunErrorMessage")
     recalculate_stats_state = sgqlc.types.Field(
         String, graphql_name="recalculateStatsState"
+    )
+    recalculate_stats_error = sgqlc.types.Field(
+        String, graphql_name="recalculateStatsError"
     )
 
 
@@ -1731,6 +1832,7 @@ class Dataset(sgqlc.types.Type):
         "preview_video_url",
         "preview_video_status",
         "recalculate_stats_state",
+        "allow_annotations_outside_frame",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(GraphqlID), graphql_name="id")
     user_id = sgqlc.types.Field(GraphqlID, graphql_name="userId")
@@ -1897,6 +1999,9 @@ class Dataset(sgqlc.types.Type):
     preview_video_status = sgqlc.types.Field(String, graphql_name="previewVideoStatus")
     recalculate_stats_state = sgqlc.types.Field(
         String, graphql_name="recalculateStatsState"
+    )
+    allow_annotations_outside_frame = sgqlc.types.Field(
+        Boolean, graphql_name="allowAnnotationsOutsideFrame"
     )
 
 
@@ -2606,6 +2711,7 @@ class Group(sgqlc.types.Type):
         "acl",
         "is_immutable",
         "notes",
+        "conservator_insights_license_key",
         "group_type",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(GraphqlID), graphql_name="id")
@@ -2617,6 +2723,9 @@ class Group(sgqlc.types.Type):
     acl = sgqlc.types.Field(Acl, graphql_name="acl")
     is_immutable = sgqlc.types.Field(Boolean, graphql_name="isImmutable")
     notes = sgqlc.types.Field(String, graphql_name="notes")
+    conservator_insights_license_key = sgqlc.types.Field(
+        String, graphql_name="conservatorInsightsLicenseKey"
+    )
     group_type = sgqlc.types.Field(
         sgqlc.types.non_null(GroupType), graphql_name="groupType"
     )
@@ -2690,7 +2799,6 @@ class Image(sgqlc.types.Type):
         "annotation_import_state_modified_at",
         "process_error_message",
         "annotation_import_error_message",
-        "annotation_url",
         "highest_target_id",
         "custom_metadata",
         "collections",
@@ -2715,6 +2823,7 @@ class Image(sgqlc.types.Type):
         "qa_status_note",
         "attached_label_set_ids",
         "attached_label_sets",
+        "allow_annotations_outside_frame",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(GraphqlID), graphql_name="id")
     filename = sgqlc.types.Field(String, graphql_name="filename")
@@ -2795,7 +2904,6 @@ class Image(sgqlc.types.Type):
     annotation_import_error_message = sgqlc.types.Field(
         String, graphql_name="annotationImportErrorMessage"
     )
-    annotation_url = sgqlc.types.Field(String, graphql_name="annotationUrl")
     highest_target_id = sgqlc.types.Field(Int, graphql_name="highestTargetId")
     custom_metadata = sgqlc.types.Field(String, graphql_name="customMetadata")
     collections = sgqlc.types.Field(
@@ -2837,6 +2945,9 @@ class Image(sgqlc.types.Type):
     )
     attached_label_sets = sgqlc.types.Field(
         sgqlc.types.list_of("LabelSet"), graphql_name="attachedLabelSets"
+    )
+    allow_annotations_outside_frame = sgqlc.types.Field(
+        Boolean, graphql_name="allowAnnotationsOutsideFrame"
     )
 
 
@@ -3035,6 +3146,7 @@ class Mutation(sgqlc.types.Type):
         "copy_filtered_frames_to_dataset",
         "copy_frames_to_dataset",
         "remove_dataset_frame_predictions",
+        "create_dataset_frames",
         "create_datasheet",
         "update_datasheet_job_state",
         "complete_datasheet_job_success",
@@ -4980,6 +5092,34 @@ class Mutation(sgqlc.types.Type):
                     sgqlc.types.Arg(
                         sgqlc.types.non_null(sgqlc.types.list_of(GraphqlID)),
                         graphql_name="datasetFrameIds",
+                        default=None,
+                    ),
+                ),
+            )
+        ),
+    )
+    create_dataset_frames = sgqlc.types.Field(
+        sgqlc.types.non_null(sgqlc.types.list_of(DatasetFrame)),
+        graphql_name="createDatasetFrames",
+        args=sgqlc.types.ArgDict(
+            (
+                (
+                    "dataset_id",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(GraphqlID),
+                        graphql_name="datasetId",
+                        default=None,
+                    ),
+                ),
+                (
+                    "dataset_frames",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(
+                            sgqlc.types.list_of(
+                                sgqlc.types.non_null(CreateDatasetFrameInput)
+                            )
+                        ),
+                        graphql_name="datasetFrames",
                         default=None,
                     ),
                 ),
@@ -7702,6 +7842,9 @@ class Query(sgqlc.types.Type):
         "datasets_query_count",
         "labelbox_frontends",
         "frames_exist_in_dataset",
+        "get_dataset_jsonl",
+        "get_dataset_videos_jsonl",
+        "get_dataset_frames_jsonl",
         "dataset_frame",
         "dataset_frames",
         "dataset_frames_by_ids",
@@ -8119,6 +8262,54 @@ class Query(sgqlc.types.Type):
                             sgqlc.types.list_of(sgqlc.types.non_null(GraphqlID))
                         ),
                         graphql_name="selectedVideoFrameIds",
+                        default=None,
+                    ),
+                ),
+            )
+        ),
+    )
+    get_dataset_jsonl = sgqlc.types.Field(
+        sgqlc.types.non_null(String),
+        graphql_name="getDatasetJsonl",
+        args=sgqlc.types.ArgDict(
+            (
+                (
+                    "dataset_id",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(GraphqlID),
+                        graphql_name="datasetId",
+                        default=None,
+                    ),
+                ),
+            )
+        ),
+    )
+    get_dataset_videos_jsonl = sgqlc.types.Field(
+        sgqlc.types.non_null(String),
+        graphql_name="getDatasetVideosJsonl",
+        args=sgqlc.types.ArgDict(
+            (
+                (
+                    "dataset_id",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(GraphqlID),
+                        graphql_name="datasetId",
+                        default=None,
+                    ),
+                ),
+            )
+        ),
+    )
+    get_dataset_frames_jsonl = sgqlc.types.Field(
+        sgqlc.types.non_null(String),
+        graphql_name="getDatasetFramesJsonl",
+        args=sgqlc.types.ArgDict(
+            (
+                (
+                    "dataset_id",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(GraphqlID),
+                        graphql_name="datasetId",
                         default=None,
                     ),
                 ),
@@ -9406,8 +9597,6 @@ class Video(sgqlc.types.Type):
         "uploaded_by",
         "uploaded_by_name",
         "uploaded_by_email",
-        "frames",
-        "frames_count",
         "frame_count",
         "annotations_count",
         "human_annotations_count",
@@ -9425,7 +9614,6 @@ class Video(sgqlc.types.Type):
         "file_locker_files",
         "annotation_import_state",
         "annotation_import_state_modified_at",
-        "annotation_url",
         "highest_target_id",
         "collections",
         "segments",
@@ -9471,6 +9659,7 @@ class Video(sgqlc.types.Type):
         "attached_label_set_ids",
         "attached_label_sets",
         "recalculate_stats_state",
+        "allow_annotations_outside_frame",
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(GraphqlID), graphql_name="id")
     filename = sgqlc.types.Field(String, graphql_name="filename")
@@ -9493,24 +9682,6 @@ class Video(sgqlc.types.Type):
     uploaded_by = sgqlc.types.Field(String, graphql_name="uploadedBy")
     uploaded_by_name = sgqlc.types.Field(String, graphql_name="uploadedByName")
     uploaded_by_email = sgqlc.types.Field(String, graphql_name="uploadedByEmail")
-    frames = sgqlc.types.Field(
-        sgqlc.types.list_of(Frame),
-        graphql_name="frames",
-        args=sgqlc.types.ArgDict(
-            (
-                ("id", sgqlc.types.Arg(GraphqlID, graphql_name="id", default=None)),
-                (
-                    "frame_index",
-                    sgqlc.types.Arg(Int, graphql_name="frameIndex", default=None),
-                ),
-                (
-                    "start_frame_index",
-                    sgqlc.types.Arg(Int, graphql_name="startFrameIndex", default=None),
-                ),
-            )
-        ),
-    )
-    frames_count = sgqlc.types.Field(Int, graphql_name="framesCount")
     frame_count = sgqlc.types.Field(Int, graphql_name="frameCount")
     annotations_count = sgqlc.types.Field(Int, graphql_name="annotationsCount")
     human_annotations_count = sgqlc.types.Field(
@@ -9538,15 +9709,12 @@ class Video(sgqlc.types.Type):
     annotation_import_state_modified_at = sgqlc.types.Field(
         Date, graphql_name="annotationImportStateModifiedAt"
     )
-    annotation_url = sgqlc.types.Field(String, graphql_name="annotationUrl")
     highest_target_id = sgqlc.types.Field(Int, graphql_name="highestTargetId")
     collections = sgqlc.types.Field(
-        sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(GraphqlID))),
-        graphql_name="collections",
+        sgqlc.types.non_null(sgqlc.types.list_of(GraphqlID)), graphql_name="collections"
     )
     segments = sgqlc.types.Field(
-        sgqlc.types.non_null(sgqlc.types.list_of(sgqlc.types.non_null(Segment))),
-        graphql_name="segments",
+        sgqlc.types.non_null(sgqlc.types.list_of(Segment)), graphql_name="segments"
     )
     datasets = sgqlc.types.Field(sgqlc.types.list_of(Dataset), graphql_name="datasets")
     acl = sgqlc.types.Field(Acl, graphql_name="acl")
@@ -9632,6 +9800,9 @@ class Video(sgqlc.types.Type):
     )
     recalculate_stats_state = sgqlc.types.Field(
         String, graphql_name="recalculateStatsState"
+    )
+    allow_annotations_outside_frame = sgqlc.types.Field(
+        Boolean, graphql_name="allowAnnotationsOutsideFrame"
     )
 
 

--- a/examples/create_dataset_frames.py
+++ b/examples/create_dataset_frames.py
@@ -10,6 +10,8 @@ from PIL import Image
 
 conservator = Conservator.default()
 
+# The assets_by_md5s query can return a lot of data;
+# specifying the fields will reduce the amount
 md5_assets_fields = [
     "md5",
     "dataset_details.dataset_frame.id",
@@ -17,25 +19,35 @@ md5_assets_fields = [
 ]
 
 
+# This function takes an image path an optional frame index,
+# and returns an object suitable to pass to the create_dataset_frames
+# API
 def upload_image_and_return_metadata(image_path, frame_index=0):
     image_md5 = md5sum_file(image_path)
 
+    # This API call checks if the image's md5 exists in Conservator
     md5_assets = conservator.query(
         Query.assets_by_md5s, md5s=[image_md5], fields=md5_assets_fields
     )
 
-    file_name = os.path.split(image_path)[1]
-
     asset = md5_assets[0]
 
+    # The assets_by_md5s API returns an object containing the md5 queried,
+    # plus lists of dataset_details and video_details objects
+    # If there is more than 0 dataset_details objects, 
+    # or more than 0 video_details objects, then the md5 is in use
     dataset_details_count = len(asset.dataset_details)
 
     video_details_count = len(asset.video_details)
 
+    file_name = os.path.split(image_path)[1]
+
     if dataset_details_count > 0 or video_details_count > 0:
         print(f"{file_name} already exists in Conservator; skipping upload")
     else:
-        # If it doesn't, upload it
+        # If the image doesn't exist, upload it to Conservator.
+        # This code is adapted from the upload_image function in
+        # FLIR/conservator/cli/cvc.py
         tries = 5
 
         url = conservator.get_dvc_hash_url(image_md5)
@@ -60,21 +72,30 @@ def upload_image_and_return_metadata(image_path, frame_index=0):
         assert r.status_code == 200
         assert r.headers["ETag"] == f'"{image_md5}"'
 
-    # Add the frame to the dataset
+    # create_dataset_frames needs the image's file size
     file_size = os.path.getsize(image_path)
 
+    # create_dataset_frames also needs the image's dimensions
     image = Image.open(image_path)
-
+    
+    # We're not creating a preview image, so the preview values
+    # are the same as the actual values.
+    # If desired, it would be possible to create and upload a preview
+    # version of the image using Pillow; e.g.
+    #
+    # im = Image.open("/home/example/image.jpg")
+    # im.thumbnail((640, 480), Image.ANTIALIAS)
+    # im.save("/home/example/preview_image.jpg", "JPEG")
     new_frame = {
         "frameIndex": frame_index,
         "previewWidth": image.width,
-        "previewHeight": image.height,
         "width": image.width,
+        "previewHeight": image.height,
         "height": image.height,
-        "md5": image_md5,
-        "fileSize": file_size,
         "previewMd5": image_md5,
+        "md5": image_md5,
         "previewFileSize": file_size,
+        "fileSize": file_size,
     }
 
     return new_frame
@@ -82,6 +103,7 @@ def upload_image_and_return_metadata(image_path, frame_index=0):
 
 if __name__ == "__main__":
     # First, read in dataset id and confirm it exists
+    # For this example, just create a new dataset manually
     dataset_id = input("Please provide a dataset id: ")
 
     try:
@@ -91,41 +113,61 @@ if __name__ == "__main__":
         print(err)
         sys.exit(1)
 
-    # Then, read in image path, and check if it exists in conservator
+    # Then, read in a directory, presumed to contain JPEG files
     image_dir = input(
         "Please enter the absolute path to a directory containing JPEGs: "
     )
 
+    # Loop until user enters a path that exists...
     while not os.path.exists(image_dir):
         image_dir = input(
             "Please enter the absolute path to a directory containing JPEGs: "
         )
 
+    # List of valid extensions
     file_extensions = ["JPG", "JPEG", "jpg", "jpeg"]
 
+    # Get a list of JPEG files from the directory
+    # We could validate further using Pillow;
+    # the Image constructor will throw an exception if
+    # the supplied file is not a valid image
     image_names = [
         os.path.join(image_dir, file)
         for file in os.listdir(image_dir)
         if any(file.endswith(ext) for ext in file_extensions)
     ]
 
+    # Need to sort the images; typically we expect images
+    # to have sequential numeric names, left padded with zeroes
+    # e.g. '00001.jpg, 00002.jpg, ...00100.jpg'
     image_names.sort()
 
-    frame = upload_image_and_return_metadata(image_names[0], 0)
-
+    # This function takea a list of objects and returns
+    # an iterator of smaller lists (in this case, of length 5 each)
     image_chunks = chunks(image_names, 5)
 
+    # Start frame indexing at 0
+    # If adding frames to a dataset that already has frames,
+    # this value should be changed to the number of already
+    # existing frames
     frame_index = 0
 
     for chunk in image_chunks:
         frames_to_create = []
 
         for image_path in chunk:
+            # Check that the path isn't None; see comment on the
+            # chunks function in FLIR/conservator/util.py
             if image_path is not None:
+                # Upload image, if necessary, and add the returned
+                # frame object to the list of frames to create
                 frame = upload_image_and_return_metadata(image_path, frame_index)
                 frames_to_create.append(frame)
                 frame_index = frame_index + 1
 
+        # Create 5 frames; it should be possible to create more
+        # than 5 at a time, depending on server load and other factors.
+        # YMMV
         new_frames = conservator.query(
             Mutation.create_dataset_frames,
             dataset_id=dataset_id,

--- a/examples/create_dataset_frames.py
+++ b/examples/create_dataset_frames.py
@@ -18,9 +18,7 @@ def upload_image_and_return_metadata(image_path, frame_index=0):
     image_md5 = md5sum_file(image_path)
 
     # This API call checks if the image's md5 exists in Conservator
-    does_md5_exist = conservator.query(
-        Query.does_md5_exist, md5=image_md5
-    )
+    does_md5_exist = conservator.query(Query.does_md5_exist, md5=image_md5)
 
     file_name = os.path.split(image_path)[1]
 
@@ -143,8 +141,7 @@ if __name__ == "__main__":
             if image_path is not None:
                 # Upload image, if necessary, and add the returned
                 # frame object to the list of frames to create
-                frame = upload_image_and_return_metadata(image_path,
-                                                         frame_index)
+                frame = upload_image_and_return_metadata(image_path, frame_index)
                 frames_to_create.append(frame)
                 frame_index = frame_index + 1
 

--- a/examples/create_dataset_frames.py
+++ b/examples/create_dataset_frames.py
@@ -34,7 +34,7 @@ def upload_image_and_return_metadata(image_path, frame_index=0):
 
     # The assets_by_md5s API returns an object containing the md5 queried,
     # plus lists of dataset_details and video_details objects
-    # If there is more than 0 dataset_details objects, 
+    # If there is more than 0 dataset_details objects,
     # or more than 0 video_details objects, then the md5 is in use
     dataset_details_count = len(asset.dataset_details)
 
@@ -77,7 +77,7 @@ def upload_image_and_return_metadata(image_path, frame_index=0):
 
     # create_dataset_frames also needs the image's dimensions
     image = Image.open(image_path)
-    
+
     # We're not creating a preview image, so the preview values
     # are the same as the actual values.
     # If desired, it would be possible to create and upload a preview

--- a/examples/create_dataset_frames.py
+++ b/examples/create_dataset_frames.py
@@ -1,0 +1,135 @@
+import os
+import requests
+import sys
+import time
+
+from FLIR.conservator.conservator import Conservator
+from FLIR.conservator.generated.schema import Mutation, Query
+from FLIR.conservator.util import md5sum_file, chunks
+from PIL import Image
+
+conservator = Conservator.default()
+
+md5_assets_fields = [
+    "md5",
+    "dataset_details.dataset_frame.id",
+    "video_details.frame.id",
+]
+
+
+def upload_image_and_return_metadata(image_path, frame_index=0):
+    image_md5 = md5sum_file(image_path)
+
+    md5_assets = conservator.query(
+        Query.assets_by_md5s, md5s=[image_md5], fields=md5_assets_fields
+    )
+
+    file_name = os.path.split(image_path)[1]
+
+    asset = md5_assets[0]
+
+    dataset_details_count = len(asset.dataset_details)
+
+    video_details_count = len(asset.video_details)
+
+    if dataset_details_count > 0 or video_details_count > 0:
+        print(f"{file_name} already exists in Conservator; skipping upload")
+    else:
+        # If it doesn't, upload it
+        tries = 5
+
+        url = conservator.get_dvc_hash_url(image_md5)
+
+        headers = {
+            "Content-type": "image/jpeg",
+            "x-amz-meta-originalfilename": file_name,
+        }
+        print(f"Uploading {image_path}.")
+        retry_count = 0
+        while retry_count < tries:
+            with open(image_path, "rb") as data:
+                r = requests.put(url, data, headers=headers)
+            if r.status_code == 502:
+                retry_count += 1
+                if retry_count < tries:
+                    print(f"Bad Gateway error, retrying {file_name} ..")
+                    time.sleep(retry_count)  # Timeout increases per retry.
+                    continue
+            else:
+                break
+        assert r.status_code == 200
+        assert r.headers["ETag"] == f'"{image_md5}"'
+
+    # Add the frame to the dataset
+    file_size = os.path.getsize(image_path)
+
+    image = Image.open(image_path)
+
+    new_frame = {
+        "frameIndex": frame_index,
+        "previewWidth": image.width,
+        "previewHeight": image.height,
+        "width": image.width,
+        "height": image.height,
+        "md5": image_md5,
+        "fileSize": file_size,
+        "previewMd5": image_md5,
+        "previewFileSize": file_size,
+    }
+
+    return new_frame
+
+
+if __name__ == "__main__":
+    # First, read in dataset id and confirm it exists
+    dataset_id = input("Please provide a dataset id: ")
+
+    try:
+        dataset = conservator.query(Query.dataset, id=dataset_id)
+    except Exception as err:
+        print(f"Error looking up dataset {dataset_id}")
+        print(err)
+        sys.exit(1)
+
+    # Then, read in image path, and check if it exists in conservator
+    image_dir = input(
+        "Please enter the absolute path to a directory containing JPEGs: "
+    )
+
+    while not os.path.exists(image_dir):
+        image_dir = input(
+            "Please enter the absolute path to a directory containing JPEGs: "
+        )
+
+    file_extensions = ["JPG", "JPEG", "jpg", "jpeg"]
+
+    image_names = [
+        os.path.join(image_dir, file)
+        for file in os.listdir(image_dir)
+        if any(file.endswith(ext) for ext in file_extensions)
+    ]
+
+    image_names.sort()
+
+    frame = upload_image_and_return_metadata(image_names[0], 0)
+
+    image_chunks = chunks(image_names, 5)
+
+    frame_index = 0
+
+    for chunk in image_chunks:
+        frames_to_create = []
+
+        for image_path in chunk:
+            if image_path is not None:
+                frame = upload_image_and_return_metadata(image_path, frame_index)
+                frames_to_create.append(frame)
+                frame_index = frame_index + 1
+
+        new_frames = conservator.query(
+            Mutation.create_dataset_frames,
+            dataset_id=dataset_id,
+            dataset_frames=frames_to_create,
+        )
+
+    print(f"Created {len(image_names)} new frames in dataset {dataset.name}")

--- a/examples/paginate_video_frames.py
+++ b/examples/paginate_video_frames.py
@@ -9,7 +9,7 @@ fields.include_field("height")
 fields.include_field("annotations.bounding_box")
 fields.include_field("annotations.labels")
 
-video = conservator.videos.all().including("name", "frames_count").first()
+video = conservator.videos.all().including("name", "frame_count").first()
 print(video)
 
 # Unless you're working with huge videos (10k+ frames), you'll probably

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # NOTE: If a package is required for conservator-cli to run, also include it in setup.py
 wheel
 sphinx
-sgqlc
+sgqlc >= 13
 click >= 8
 tqdm
 pytest

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open("README.md", "r") as fh:
 # Packages only used for developing (pytest, black, etc.) should be placed
 # in requirements.txt instead.
 INSTALL_REQUIRES = [
-    "sgqlc",
+    "sgqlc >= 13",
     "click >= 8",
     "tqdm",
     "requests",

--- a/test/README.md
+++ b/test/README.md
@@ -20,5 +20,7 @@ To run tests manually, from the root directory:
 
 ```sh
 $ pytest test/unit
-$ pytest test/integration
+$ pytest test/integration --server-deployment=<server_type>
 ```
+
+where `<server_type>` is either `docker`, `kind`, or `minikube`, depending on how Conservator is being run. `<server_type>` defaults to `kind`.

--- a/test/integration/test_media.py
+++ b/test/integration/test_media.py
@@ -64,7 +64,7 @@ def test_upload_video(conservator, test_data):
     assert video is not None
     assert video.id == media_id
     assert video.name == "adas_thermal.mp4"
-    assert video.frames_count == 60
+    assert video.frame_count == 60
 
 
 def test_upload_many_in_parallel(conservator, test_data):
@@ -166,7 +166,7 @@ def test_get_all_frames_paginated(conservator, test_data):
 
     paginated_frames = video.get_all_frames_paginated()
     frames = list(paginated_frames)
-    assert len(frames) == video.frames_count
+    assert len(frames) == video.frame_count
     for i, frame in enumerate(frames):
         assert frame.frame_index == i
         assert frame.video_id == video.id


### PR DESCRIPTION
Adds support for the Conservator `createDatasetFrames` API, and example code.

**File Changes:**

`examples/paginate_video_frames.py`
`FLIR/conservator/fields_manager.py`
`test/integration/test_media.py`
 - Replaced deprecated `frames_count` field with `frame_count`

`FLIR/conservator/generated/generate.sh`
 - Removed `--exclude-deprecated` parameter, because some tests/other code seems to depend on deprecated fields/APIs

`FLIR/conservator/generated/schema.py`
 - Updated schema with latest changes from Conservator

`examples/create_dataset_frames.py`
 - Example code showing how to use the new API to create dataset frames

`test/README.md`
 - Added description of previously undocumented `--server-deployment` command-line arg


[[JIRA Task](https://jiracommercial.flir.com/browse/CON-2527)]
