### PR TITLE
extra rules for annotation targetId in dataset validation

### DIFF
--- a/test/data/txt/dupe-index/index.json
+++ b/test/data/txt/dupe-index/index.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08dc0e2ced7e59f6b6d6dd9877181edfee67a75a6c04aa14b8ff7db24a9c5641
+size 11699

--- a/test/data/txt/good-index/index.json
+++ b/test/data/txt/good-index/index.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c87e1c8dd0cc9da72fcc365248d7ee12072450f81088826e86bae3266bfcb30b
+size 11699

--- a/test/data/txt/neg-index/index.json
+++ b/test/data/txt/neg-index/index.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aea3386485ecee871910e97a6bc92d33c34845c07f7678ab6d83ebac3ae73d04
+size 11701

--- a/test/integration/test_local_dataset.py
+++ b/test/integration/test_local_dataset.py
@@ -66,6 +66,7 @@ def test_validation(conservator, tmp_cwd, test_data):
     neg_dset = LocalDataset(conservator, neg_index)
     assert not neg_dset.validate_index()
 
+    # duplicates pass validation, would fail on attempt to push
     dupe_index = test_data / "txt" / "dupe-index"
     dupe_dset = LocalDataset(conservator, dupe_index)
-    assert not dupe_dset.validate_index()
+    assert dupe_dset.validate_index()

--- a/test/integration/test_local_dataset.py
+++ b/test/integration/test_local_dataset.py
@@ -55,3 +55,17 @@ def test_add_commit_push_frame(conservator, tmp_cwd, test_data):
         if max_tries <= 0:
             break
     assert os.path.exists(local_dset.frames_path)
+
+
+def test_validation(conservator, tmp_cwd, test_data):
+    good_index = test_data / "txt" / "good-index"
+    good_dset = LocalDataset(conservator, good_index)
+    assert good_dset.validate_index()
+
+    neg_index = test_data / "txt" / "neg-index"
+    neg_dset = LocalDataset(conservator, neg_index)
+    assert not neg_dset.validate_index()
+
+    dupe_index = test_data / "txt" / "dupe-index"
+    dupe_dset = LocalDataset(conservator, dupe_index)
+    assert not dupe_dset.validate_index()


### PR DESCRIPTION
In the past the server validation for annotations was looser,
so there are some older datasets that have problems with
anotation targetIds that make cvc push fail:
* sometimes targetIds were reused in the same frame
* sometimes negative targetIds were created

Beef up validation here to help users track down negative or duplicate
targetIds when a cvc push of such a dataset is failing. Add these new checks
before the general schema check, so that the new more helpful message will get
shown for negative target ids (the general schema complaint will get shown
afterwards).
