### PR TITLE
Feature/jenkins image flexibility

### DIFF
--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -60,13 +60,18 @@ pipeline {
         FC_GIT_REPO = "ssh://git@github.com/FLIR/flirconservator"
         // version of conservator known to have working KInD config
         KIND_GIT_HASH = "745de5b4a1b3ef504f2f43b2ecaf8e88bc43de8d"
+
+        // uid of jenkins user, for fixing up ownership of checked-out source
+        BUILD_UID = sh(returnStdout: true, script: "stat -c '%u' ${WORKSPACE}").trim()
       }
       stages {
         stage("Prepare conservator image") {
           steps {
+            echo "BUILD_UID=${env.BUILD_UID}"
             // check out conservator source code now, in case it is needed for build scripts
             sshagent(credentials: ["flir-service-key"]) {
-              sh "git clone ${FC_GIT_REPO} fc"
+              sh "git clone ${FC_GIT_REPO} fc && chown -R ${BUILD_UID} fc"
+              writeFile(file: "fc/deploy_key", text: "STUB")
             }
             script {
               def DOMAIN

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -82,8 +82,8 @@ pipeline {
 
                 case 'LOCAL':
                   DOMAIN = "jenkins-cli-tests"
-                  find_commit_cmd = "cd fc && git checkout ${LOCAL_BRANCH} && git rev-parse --short HEAD"
-                  TAG = sh(returnStdout: true, script: find_commit_cmd)
+                  find_commit_cmd = "cd fc && git checkout ${LOCAL_BRANCH} > /dev/null && git rev-parse --short HEAD"
+                  TAG = sh(returnStdout: true, script: find_commit_cmd).trim()
                   echo "LOCAL: DOMAIN=${DOMAIN}, TAG=${TAG}"
 
                   // configure image build
@@ -91,6 +91,8 @@ pipeline {
                   sh "echo TAG=${TAG} >> fc/docker/deploy/defaults.sh"
                   sh "echo GIT_COMMIT=${TAG} >> fc/docker/deploy/defaults.sh"
                   sh "echo GIT_BRANCH=${LOCAL_BRANCH} >> fc/docker/deploy/defaults.sh"
+                  echo "defaults.sh:"
+                  sh "cat fc/docker/deploy/defaults.sh"
 
                   // do the docker image build, which wants to do its own shallow git clone
                   sshagent(credentials: ["flir-service-key"]) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ Pillow
 jsonschema
 dataclasses; python_version<'3.7'
 pymongo
+# docker is for building conservator image from inside jenkins pipeline
+docker

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -35,9 +35,14 @@ RUN curl -sSL https://github.com/shyiko/kubetpl/releases/download/0.9.0/kubetpl-
 
 # Install AWS CLI to pull docker images from ECR
 RUN apt-get update \
-    && apt-get install unzip \
-    && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-    && unzip awscliv2.zip \
-    && ./aws/install
+    && apt-get install unzip 
+# aws cli v1
+RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" \
+    && unzip awscli-bundle.zip \
+    && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+# aws cli v2
+#RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+#    && unzip awscliv2.zip \
+#    && ./aws/install
 
 ENV RUNNING_IN_CLI_TESTING_DOCKER=True

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.8-slim-bullseye
 
 # Install standalone apt dependencies
 RUN apt-get update \

--- a/test/integration/cluster/build-fc-docker.sh
+++ b/test/integration/cluster/build-fc-docker.sh
@@ -1,0 +1,36 @@
+#!/bin/sh -ev
+# ./build-fc-docker.sh <docker reponame> <git commit> <git branch> <path to git repo>
+
+if [ $# != 4 ] ; then
+  echo 2>&1 "Usage: $0  <docker reponame> <git commit> <git branch> <path to git repo>"
+  exit 1
+fi
+
+DOCKER_REPO=$1
+GIT_COMMIT=$2
+GIT_BRANCH=$3
+SOURCE_PATH=$4
+
+# create source tarball for build to use
+cd $SOURCE_PATH
+git archive -o docker/deploy/flirmachinelearning.tar --prefix=flirmachinelearning/ ${GIT_COMMIT}
+mkdir -p flirmachinelearning
+echo ${GIT_COMMIT} > flirmachinelearning/conservator_build.txt
+tar --append -f docker/deploy/flirmachinelearning.tar flirmachinelearning/conservator_build.txt
+
+# configure image build
+cd $SOURCE_PATH/docker/deploy
+cat <<EOF >> defaults.sh
+REPO=${DOCKER_REPO}
+TAG=${GIT_COMMIT}
+GIT_COMMIT=${GIT_COMMIT}
+GIT_BRANCH=${GIT_BRANCH}
+EOF
+echo "defaults.sh:"
+cat defaults.sh
+
+# build can skip installing ssh key (using tarball, it won't need keys to clone again)
+echo "## using tarball, skip installing ssh key" > ssh_key_template.sh
+
+# run the image build
+./build_pipeline.sh --local-only

--- a/test/integration/cluster/kind-init.env.tmpl
+++ b/test/integration/cluster/kind-init.env.tmpl
@@ -1,3 +1,3 @@
-IMAGE=$AWS_DOMAIN/conservator_webapp:prod
+IMAGE=$IMAGE
 KIND_CONFIG=$TOP_DIR/../kind.yaml
 KIND_OPTS="--insecure-skip-tls-verify=true"


### PR DESCRIPTION
### jenkins: support testing against different conservator images

The pipeline still defaults to testing against official prod image, but jenkins jobs can set the new parameters to different values to allow using other images, including a image locally built from a specified conservator git branch.