### PR TITLE
cvc: improve user experience for creating associated files

### DIFF
--- a/docs/usage/cvc_guide.rst
+++ b/docs/usage/cvc_guide.rst
@@ -40,8 +40,10 @@ The basic workflow to clone and download a dataset::
     $ cd "DATASET NAME/"     # the default directory is the name of the dataset
     $ cvc download           # download media
 
-Now, you can make modifications to ``index.json`` or ``associated_files``. Then,
-publish your changes::
+Now, you can make modifications to ``index.json`` or ``associated_files``. In
+addition to modifying existing associated files, you can add one or more new
+associated files by copying them into the ``associated_files`` subdirectory.
+Then, publish your changes::
 
     $ cvc publish "Your commit message here"
 
@@ -297,8 +299,8 @@ and push. All three steps can be done with a single command::
 
 If you don't have any images staged, the upload process will be skipped.
 So this is also a suitable replacement for commit, push.
-
-At this time, associated files will not be included in this commit.
+Any modifications or additions to associated files will also be included
+in the commit.
 
 
 Pull Local Commits

--- a/test/integration/test_cvc.py
+++ b/test/integration/test_cvc.py
@@ -44,18 +44,7 @@ def test_publish_image(default_conservator, tmp_cwd, test_data):
     p = cvc("publish", "My test commit")
     assert p.returncode == 0
 
-    max_tries = 10
-    tries = 0
-    while tries < max_tries:
-        commits = dataset.get_commit_history()
-        if len(commits) < 3:
-            # New datasets begin with 2 commits.
-            tries += 1
-            if tries < max_tries:
-                sleep(tries)  # It takes a bit for the commit to be available.
-        else:
-            break
-
+    dataset.wait_for_history_len(3, max_tries=100)
     latest_commit = dataset.get_commit_by_id("HEAD")
     assert latest_commit.short_message == "My test commit"
 


### PR DESCRIPTION
* mention using `cvc publish` to create associated files in cvc guide
* mention using `cvc publish` to create associated files in `cvc add` error message, if user (unsuccessfully) attempts to use `cvc add` instead
* fix race in `cvc publish` that sometimes ended with working dir at previous commit, making a new associated file disappear from working dir until next `cvc pull` got the working dir up-to-date