### PR TITLE
Con 2610 20220504 update dataset annotation ap is

### DIFF
--- a/FLIR/conservator/generated/schema.py
+++ b/FLIR/conservator/generated/schema.py
@@ -1339,7 +1339,6 @@ class Annotation(sgqlc.types.Type):
     __field_names__ = (
         "id",
         "target_id",
-        "label",
         "labels",
         "label_id",
         "bounding_box",
@@ -1353,9 +1352,6 @@ class Annotation(sgqlc.types.Type):
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(GraphqlID), graphql_name="id")
     target_id = sgqlc.types.Field(String, graphql_name="targetId")
-    label = sgqlc.types.Field(
-        sgqlc.types.non_null(AllowedLabelCharacters), graphql_name="label"
-    )
     labels = sgqlc.types.Field(
         sgqlc.types.non_null(
             sgqlc.types.list_of(sgqlc.types.non_null(AllowedLabelCharacters))
@@ -2016,7 +2012,6 @@ class DatasetAnnotation(sgqlc.types.Type):
     __field_names__ = (
         "id",
         "target_id",
-        "label",
         "labels",
         "label_id",
         "bounding_box",
@@ -2030,9 +2025,6 @@ class DatasetAnnotation(sgqlc.types.Type):
     )
     id = sgqlc.types.Field(sgqlc.types.non_null(GraphqlID), graphql_name="id")
     target_id = sgqlc.types.Field(String, graphql_name="targetId")
-    label = sgqlc.types.Field(
-        sgqlc.types.non_null(AllowedLabelCharacters), graphql_name="label"
-    )
     labels = sgqlc.types.Field(
         sgqlc.types.non_null(
             sgqlc.types.list_of(sgqlc.types.non_null(AllowedLabelCharacters))

--- a/FLIR/conservator/generated/schema.py
+++ b/FLIR/conservator/generated/schema.py
@@ -518,6 +518,7 @@ class CreateDatasetFrameInput(sgqlc.types.Input):
         "md5",
         "file_size",
         "analytics_md5",
+        "analytics_file_size",
         "preview_md5",
         "preview_file_size",
         "custom_metadata",
@@ -552,6 +553,7 @@ class CreateDatasetFrameInput(sgqlc.types.Input):
     md5 = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name="md5")
     file_size = sgqlc.types.Field(sgqlc.types.non_null(Float), graphql_name="fileSize")
     analytics_md5 = sgqlc.types.Field(String, graphql_name="analyticsMd5")
+    analytics_file_size = sgqlc.types.Field(Float, graphql_name="analyticsFileSize")
     preview_md5 = sgqlc.types.Field(
         sgqlc.types.non_null(String), graphql_name="previewMd5"
     )
@@ -2070,6 +2072,8 @@ class DatasetFrame(sgqlc.types.Type):
         "index",
         "frame_id",
         "video_id",
+        "labelbox_data_row_id",
+        "file_size",
         "frame_index",
         "url",
         "height",
@@ -2077,6 +2081,7 @@ class DatasetFrame(sgqlc.types.Type):
         "preview_url",
         "preview_height",
         "preview_width",
+        "preview_file_size",
         "created_at",
         "modified_at",
         "next",
@@ -2105,6 +2110,7 @@ class DatasetFrame(sgqlc.types.Type):
         "md5",
         "preview_md5",
         "analytics_md5",
+        "analytics_file_size",
         "location",
         "description",
         "spectrum",
@@ -2127,6 +2133,8 @@ class DatasetFrame(sgqlc.types.Type):
     video_id = sgqlc.types.Field(
         sgqlc.types.non_null(GraphqlID), graphql_name="videoId"
     )
+    labelbox_data_row_id = sgqlc.types.Field(String, graphql_name="labelboxDataRowId")
+    file_size = sgqlc.types.Field(sgqlc.types.non_null(Float), graphql_name="fileSize")
     frame_index = sgqlc.types.Field(
         sgqlc.types.non_null(Int), graphql_name="frameIndex"
     )
@@ -2141,6 +2149,9 @@ class DatasetFrame(sgqlc.types.Type):
     )
     preview_width = sgqlc.types.Field(
         sgqlc.types.non_null(Int), graphql_name="previewWidth"
+    )
+    preview_file_size = sgqlc.types.Field(
+        sgqlc.types.non_null(Float), graphql_name="previewFileSize"
     )
     created_at = sgqlc.types.Field(
         sgqlc.types.non_null(Float), graphql_name="createdAt"
@@ -2199,6 +2210,7 @@ class DatasetFrame(sgqlc.types.Type):
     md5 = sgqlc.types.Field(String, graphql_name="md5")
     preview_md5 = sgqlc.types.Field(String, graphql_name="previewMd5")
     analytics_md5 = sgqlc.types.Field(String, graphql_name="analyticsMd5")
+    analytics_file_size = sgqlc.types.Field(Float, graphql_name="analyticsFileSize")
     location = sgqlc.types.Field(String, graphql_name="location")
     description = sgqlc.types.Field(String, graphql_name="description")
     spectrum = sgqlc.types.Field(String, graphql_name="spectrum")
@@ -2234,6 +2246,8 @@ class DatasetFrameOnly(sgqlc.types.Type):
         "owner",
         "frame_id",
         "video_id",
+        "labelbox_data_row_id",
+        "file_size",
         "frame_index",
         "url",
         "height",
@@ -2241,6 +2255,7 @@ class DatasetFrameOnly(sgqlc.types.Type):
         "preview_url",
         "preview_height",
         "preview_width",
+        "preview_file_size",
         "created_at",
         "modified_at",
         "annotations",
@@ -2256,6 +2271,7 @@ class DatasetFrameOnly(sgqlc.types.Type):
         "md5",
         "preview_md5",
         "analytics_md5",
+        "analytics_file_size",
         "dataset_frame_name",
         "attributes",
     )
@@ -2267,6 +2283,10 @@ class DatasetFrameOnly(sgqlc.types.Type):
     video_id = sgqlc.types.Field(
         sgqlc.types.non_null(GraphqlID), graphql_name="videoId"
     )
+    labelbox_data_row_id = sgqlc.types.Field(
+        GraphqlID, graphql_name="labelboxDataRowId"
+    )
+    file_size = sgqlc.types.Field(sgqlc.types.non_null(Float), graphql_name="fileSize")
     frame_index = sgqlc.types.Field(
         sgqlc.types.non_null(Int), graphql_name="frameIndex"
     )
@@ -2281,6 +2301,9 @@ class DatasetFrameOnly(sgqlc.types.Type):
     )
     preview_width = sgqlc.types.Field(
         sgqlc.types.non_null(Int), graphql_name="previewWidth"
+    )
+    preview_file_size = sgqlc.types.Field(
+        sgqlc.types.non_null(Float), graphql_name="previewFileSize"
     )
     created_at = sgqlc.types.Field(
         sgqlc.types.non_null(Float), graphql_name="createdAt"
@@ -2318,6 +2341,7 @@ class DatasetFrameOnly(sgqlc.types.Type):
     md5 = sgqlc.types.Field(String, graphql_name="md5")
     preview_md5 = sgqlc.types.Field(String, graphql_name="previewMd5")
     analytics_md5 = sgqlc.types.Field(String, graphql_name="analyticsMd5")
+    analytics_file_size = sgqlc.types.Field(Float, graphql_name="analyticsFileSize")
     dataset_frame_name = sgqlc.types.Field(
         sgqlc.types.non_null(String), graphql_name="datasetFrameName"
     )
@@ -2805,7 +2829,7 @@ class Image(sgqlc.types.Type):
         "file_locker_files",
         "annotation_import_state",
         "annotation_import_state_modified_at",
-        "process_error_message",
+        "process_video_error_message",
         "annotation_import_error_message",
         "highest_target_id",
         "custom_metadata",
@@ -2907,8 +2931,8 @@ class Image(sgqlc.types.Type):
     annotation_import_state_modified_at = sgqlc.types.Field(
         Date, graphql_name="annotationImportStateModifiedAt"
     )
-    process_error_message = sgqlc.types.Field(
-        String, graphql_name="processErrorMessage"
+    process_video_error_message = sgqlc.types.Field(
+        String, graphql_name="processVideoErrorMessage"
     )
     annotation_import_error_message = sgqlc.types.Field(
         String, graphql_name="annotationImportErrorMessage"
@@ -4492,6 +4516,14 @@ class Mutation(sgqlc.types.Type):
         args=sgqlc.types.ArgDict(
             (
                 (
+                    "dataset_frame_id",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(GraphqlID),
+                        graphql_name="datasetFrameId",
+                        default=None,
+                    ),
+                ),
+                (
                     "input",
                     sgqlc.types.Arg(
                         sgqlc.types.non_null(UpdateDatasetAnnotationInput),
@@ -4542,9 +4574,19 @@ class Mutation(sgqlc.types.Type):
         args=sgqlc.types.ArgDict(
             (
                 (
-                    "id",
+                    "dataset_frame_id",
                     sgqlc.types.Arg(
-                        sgqlc.types.non_null(GraphqlID), graphql_name="id", default=None
+                        sgqlc.types.non_null(GraphqlID),
+                        graphql_name="datasetFrameId",
+                        default=None,
+                    ),
+                ),
+                (
+                    "annotation_id",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(GraphqlID),
+                        graphql_name="annotationId",
+                        default=None,
                     ),
                 ),
             )
@@ -4556,9 +4598,19 @@ class Mutation(sgqlc.types.Type):
         args=sgqlc.types.ArgDict(
             (
                 (
-                    "id",
+                    "dataset_frame_id",
                     sgqlc.types.Arg(
-                        sgqlc.types.non_null(GraphqlID), graphql_name="id", default=None
+                        sgqlc.types.non_null(GraphqlID),
+                        graphql_name="datasetFrameId",
+                        default=None,
+                    ),
+                ),
+                (
+                    "annotation_id",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(GraphqlID),
+                        graphql_name="annotationId",
+                        default=None,
                     ),
                 ),
             )
@@ -4570,9 +4622,19 @@ class Mutation(sgqlc.types.Type):
         args=sgqlc.types.ArgDict(
             (
                 (
-                    "id",
+                    "dataset_frame_id",
                     sgqlc.types.Arg(
-                        sgqlc.types.non_null(GraphqlID), graphql_name="id", default=None
+                        sgqlc.types.non_null(GraphqlID),
+                        graphql_name="datasetFrameId",
+                        default=None,
+                    ),
+                ),
+                (
+                    "annotation_id",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(GraphqlID),
+                        graphql_name="annotationId",
+                        default=None,
                     ),
                 ),
             )
@@ -4584,10 +4646,26 @@ class Mutation(sgqlc.types.Type):
         args=sgqlc.types.ArgDict(
             (
                 (
-                    "input",
+                    "dataset_frame_id",
                     sgqlc.types.Arg(
-                        sgqlc.types.non_null(UpdateQaStatusNoteInput),
-                        graphql_name="input",
+                        sgqlc.types.non_null(GraphqlID),
+                        graphql_name="datasetFrameId",
+                        default=None,
+                    ),
+                ),
+                (
+                    "annotation_id",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(GraphqlID),
+                        graphql_name="annotationId",
+                        default=None,
+                    ),
+                ),
+                (
+                    "qa_status_note",
+                    sgqlc.types.Arg(
+                        sgqlc.types.non_null(String),
+                        graphql_name="qaStatusNote",
                         default=None,
                     ),
                 ),
@@ -9509,6 +9587,7 @@ class Settings(sgqlc.types.Type):
         "labelbox_enabled",
         "sqa_enabled",
         "object_detect_enabled",
+        "conservator_insights_docs_url",
     )
     commit = sgqlc.types.Field(String, graphql_name="commit")
     jira_collector_url = sgqlc.types.Field(String, graphql_name="jiraCollectorUrl")
@@ -9522,6 +9601,9 @@ class Settings(sgqlc.types.Type):
     )
     object_detect_enabled = sgqlc.types.Field(
         sgqlc.types.non_null(Boolean), graphql_name="objectDetectEnabled"
+    )
+    conservator_insights_docs_url = sgqlc.types.Field(
+        String, graphql_name="conservatorInsightsDocsUrl"
     )
 
 

--- a/examples/dataset_annotation_qa.py
+++ b/examples/dataset_annotation_qa.py
@@ -3,10 +3,14 @@ from FLIR.conservator.generated.schema import Mutation, UpdateQaStatusNoteInput
 
 conservator = Conservator.default()
 
+dataset_frame_id = input("Please provide a dataset frame id: ")
+
 annotation_id = input("Please provide a dataset annotation id: ")
 
 annotation = conservator.query(
-    Mutation.request_changes_dataset_annotation, id=annotation_id
+    Mutation.request_changes_dataset_annotation,
+    dataset_frame_id=dataset_frame_id,
+    annotation_id=annotation_id,
 )
 
 print("Changes have been requested!")
@@ -16,9 +20,9 @@ request_changes_note = input("Add a note on your annotation change request: ")
 
 annotation = conservator.query(
     Mutation.update_qa_status_note_dataset_annotation,
-    input=UpdateQaStatusNoteInput(
-        id=annotation_id, qa_status_note=request_changes_note
-    ),
+    dataset_frame_id=dataset_frame_id,
+    annotation_id=annotation_id,
+    qa_status_note=request_changes_note,
 )
 
 print("Note has been added!")


### PR DESCRIPTION
Updates schema.py

**File Changes:**

`FLIR/conservator/generated/schema.py`
 - Updated schema to match latest conservator release
 - Removed `label` fields from DatasetAnnotation/Annotation - they are deprecated in Conservator

`examples/dataset_annotation_qa.py`
 - Updated query calls to match new API signature

[[JIRA Task](https://jiracommercial.flir.com/browse/CON-2610)]
