### PR TITLE
Con 2819 20220817 improve cvc download

### DIFF
--- a/FLIR/conservator/file_transfers.py
+++ b/FLIR/conservator/file_transfers.py
@@ -104,9 +104,9 @@ class ConservatorFileTransfers:
             retries = 0
             while retries < max_retries:
                 response = requests.get(url, stream=True, allow_redirects=True)
-                logger.info('Got status code %s', response.status_code)
                 if response.ok:
                     break
+                logger.info('Got status code %s', response.status_code)
                 if response.status_code == 502:
                     retries += 1
                     if retries < max_retries:

--- a/FLIR/conservator/util.py
+++ b/FLIR/conservator/util.py
@@ -96,19 +96,19 @@ def compare_conservator_cli_version():
     if semver.compare(latest_version, current_version) == 0:
         return True
     if semver.compare(latest_version, current_version) == -1:
-        logger.warning("You are using Conservator-cli version %s" % current_version)
-        logger.warning("Please upgrade to the latest version %s" % latest_version)
+        logger.warning("You are using Conservator-cli version %s", current_version)
+        logger.warning("Please upgrade to the latest version %s", latest_version)
         return False
     if semver.compare(latest_version, current_version) == 1:
         logger.warning(
-            "You are using an unreleased version of Conservator-cli (%s)"
-            % current_version
+            "You are using an unreleased version of Conservator-cli (%s)",
+            current_version,
         )
         logger.warning(
             "Please be aware that this version may not be supported in the future"
         )
         logger.warning(
-            "For reference, the current supported version of Conservator-cli is %s"
-            % latest_version
+            "For reference, the current supported version of Conservator-cli is %s",
+            latest_version,
         )
         return False


### PR DESCRIPTION
Users have complained about issues using `cvc download`. This PR attempts to disgnose and fix these issues by reporting the exact status codes of failed downloads, and attempting to retry 504 errors.

**File Changes:**

`FLIR/conservator/file_transfers.py`
 - Print out non-successful status codes
 - Automatically retry on 504 error
 - Fix some linting issues


[[JIRA Task](https://jiracommercial.flir.com/browse/CON-2819)]
