### PR TITLE
Con 2811 20220823 cleanup docker after test

### DIFF
--- a/FLIR/conservator/util.py
+++ b/FLIR/conservator/util.py
@@ -90,25 +90,25 @@ def get_conservator_cli_version():
 
 
 def compare_conservator_cli_version():
-    current_version = cli_ver
-    latest_version = get_conservator_cli_version()
+    current_version = semver.VersionInfo.parse(cli_ver)
+    latest_version = semver.VersionInfo.parse(get_conservator_cli_version())
 
-    if semver.compare(latest_version, current_version) == 0:
+    if latest_version == current_version:
         return True
-    if semver.compare(latest_version, current_version) == -1:
-        logger.warning("You are using Conservator-cli version %s" % current_version)
-        logger.warning("Please upgrade to the latest version %s" % latest_version)
+    if latest_version < current_version:
+        logger.warning("You are using Conservator-cli version %s", current_version)
+        logger.warning("Please upgrade to the latest version %s", latest_version)
         return False
-    if semver.compare(latest_version, current_version) == 1:
+    if latest_version > current_version:
         logger.warning(
-            "You are using an unreleased version of Conservator-cli (%s)"
-            % current_version
+            "You are using an unreleased version of Conservator-cli (%s)",
+            current_version,
         )
         logger.warning(
             "Please be aware that this version may not be supported in the future"
         )
         logger.warning(
-            "For reference, the current supported version of Conservator-cli is %s"
-            % latest_version
+            "For reference, the current supported version of Conservator-cli is %s",
+            latest_version,
         )
         return False

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -195,7 +195,6 @@ pipeline {
       cleanWs()
       sh "kind delete cluster"
       sh "docker image prune"
-      sh "docker system prune -a --filter 'until=120h'"
     }
   }
 }

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -7,6 +7,12 @@ pipeline {
     }
   }
   stages {
+    stage('Cleanup') {
+      steps {
+        sh "docker image prune"
+        sh "docker system prune -a --filter 'until=120h'"
+      }
+    }
     stage("Install") {
       steps {
         sh "pip install --no-cache-dir -r requirements.txt"

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -188,6 +188,8 @@ pipeline {
       sh "chmod -R 777 ."
       cleanWs()
       sh "kind delete cluster"
+      sh "docker image prune"
+      sh "docker system prune -a --filter 'until=120h'"
     }
   }
 }


### PR DESCRIPTION
Adds cleanup steps to jenkins build process, to remove intermediate docker build images, and other docker images more than 5 days old.

**File Changes:**

`FLIR/conservator/util.py`
 - Refactored `semver` usage

`jenkins-pipelines/linux_desktop_build.groovy`
 - Adds commands to clean up docker images

[[JIRA Task](https://jiracommercial.flir.com/browse/CON-2811)]
