### PR TITLE
Con 2840 20220831 filter docker image purge

### DIFF
--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -187,9 +187,9 @@ pipeline {
       sh "kind delete cluster"
       sh "docker image prune"
       // Note in --filter the "*" character will not match a "/"
-      sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs docker image rm -f"
-      sh "docker image ls --filter reference='*conservator*' --quiet | xargs docker image rm -f"
-      sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs docker image rm"
+      // sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs docker image rm -f"
+      // sh "docker image ls --filter reference='*conservator*' --quiet | xargs docker image rm -f"
+      // sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs docker image rm"
       // This docker executes as root, so any files created (python cache, etc.) can't be deleted
       // by the Jenkins worker. We need to lower permissions before asking to clean up.
       sh "chmod -R 777 ."

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -187,9 +187,9 @@ pipeline {
       sh "kind delete cluster"
       sh "docker image prune"
       // Note in --filter the "*" character will not match a "/"
-      sh "docker image rm $(docker image ls --filter reference='*/*conservator*' --quiet)"
-      sh "docker image rm $(docker image ls --filter reference='*conservator*' --quiet)"
-      // sh "docker image rm $(docker image ls --filter reference='*conservator-cli*/*' --quiet)"
+      sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs docker image rm"
+      sh "docker image ls --filter reference='*conservator*' --quiet | xargs docker image rm"
+      // sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs docker image rm"
       // This docker executes as root, so any files created (python cache, etc.) can't be deleted
       // by the Jenkins worker. We need to lower permissions before asking to clean up.
       sh "chmod -R 777 ."

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -198,9 +198,9 @@ pipeline {
       cleanWs()
       sh "docker image prune"
       // Note in --filter the "*" character will not match a "/"
-      sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs docker image rm -f"
-      sh "docker image ls --filter reference='*conservator*' --quiet | xargs docker image rm -f"
-      sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs docker image rm"
+      sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs -r docker image rm -f"
+      sh "docker image ls --filter reference='*conservator*' --quiet | xargs -r docker image rm -f"
+      sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs -r docker image rm"
     }
   }
 }

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -200,7 +200,7 @@ pipeline {
       // Note in --filter the "*" character will not match a "/"
       sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs -r docker image rm -f || echo 'Error cleaning up docker!'"
       sh "docker image ls --filter reference='*conservator*' --quiet | xargs -r docker image rm -f || echo 'Error cleaning up docker!'"
-      sh 'docker rmi --force $(docker images --quiet --filter=reference="conservator-cli/test")'
+      sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs -r docker image rm -f || echo 'Error cleaning up docker!'"
     }
   }
 }

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -187,8 +187,8 @@ pipeline {
       sh "kind delete cluster"
       sh "docker image prune"
       // Note in --filter the "*" character will not match a "/"
-      sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs docker image rm"
-      sh "docker image ls --filter reference='*conservator*' --quiet | xargs docker image rm"
+      sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs docker image rm -f"
+      sh "docker image ls --filter reference='*conservator*' --quiet | xargs docker image rm -f"
       // sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs docker image rm"
       // This docker executes as root, so any files created (python cache, etc.) can't be deleted
       // by the Jenkins worker. We need to lower permissions before asking to clean up.

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -185,11 +185,6 @@ pipeline {
   post {
     cleanup {
       sh "kind delete cluster"
-      sh "docker image prune"
-      // Note in --filter the "*" character will not match a "/"
-      // sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs docker image rm -f"
-      // sh "docker image ls --filter reference='*conservator*' --quiet | xargs docker image rm -f"
-      // sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs docker image rm"
       // This docker executes as root, so any files created (python cache, etc.) can't be deleted
       // by the Jenkins worker. We need to lower permissions before asking to clean up.
       sh "chmod -R 777 ."
@@ -201,6 +196,11 @@ pipeline {
       fi
       """
       cleanWs()
+      sh "docker image prune"
+      // Note in --filter the "*" character will not match a "/"
+      sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs docker image rm -f"
+      sh "docker image ls --filter reference='*conservator*' --quiet | xargs docker image rm -f"
+      sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs docker image rm"
     }
   }
 }

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -200,7 +200,7 @@ pipeline {
       // Note in --filter the "*" character will not match a "/"
       sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs -r docker image rm -f || echo 'Error cleaning up docker!'"
       sh "docker image ls --filter reference='*conservator*' --quiet | xargs -r docker image rm -f || echo 'Error cleaning up docker!'"
-      sh "docker rmi --force $(docker images --quiet --filter=reference='conservator-cli/test')"
+      sh 'docker rmi --force $(docker images --quiet --filter=reference="conservator-cli/test")'
     }
   }
 }

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -189,7 +189,7 @@ pipeline {
       // Note in --filter the "*" character will not match a "/"
       sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs docker image rm -f"
       sh "docker image ls --filter reference='*conservator*' --quiet | xargs docker image rm -f"
-      // sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs docker image rm"
+      sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs docker image rm"
       // This docker executes as root, so any files created (python cache, etc.) can't be deleted
       // by the Jenkins worker. We need to lower permissions before asking to clean up.
       sh "chmod -R 777 ."

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -200,7 +200,7 @@ pipeline {
       // Note in --filter the "*" character will not match a "/"
       sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs -r docker image rm -f || echo 'Error cleaning up docker!'"
       sh "docker image ls --filter reference='*conservator*' --quiet | xargs -r docker image rm -f || echo 'Error cleaning up docker!'"
-      sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs -r docker image rm -f || echo 'Error cleaning up docker!'"
+      sh "docker rmi --force $(docker images --quiet --filter=reference='conservator-cli/test')"
     }
   }
 }

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -198,9 +198,9 @@ pipeline {
       cleanWs()
       sh "docker image prune"
       // Note in --filter the "*" character will not match a "/"
-      sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs -r docker image rm -f"
-      sh "docker image ls --filter reference='*conservator*' --quiet | xargs -r docker image rm -f"
-      sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs -r docker image rm"
+      sh "docker image ls --filter reference='*/*conservator*' --quiet | xargs -r docker image rm -f || echo 'Error cleaning up docker!'"
+      sh "docker image ls --filter reference='*conservator*' --quiet | xargs -r docker image rm -f || echo 'Error cleaning up docker!'"
+      sh "docker image ls --filter reference='*conservator-cli*/*' --quiet | xargs -r docker image rm -f || echo 'Error cleaning up docker!'"
     }
   }
 }


### PR DESCRIPTION
Changes the commands that clean up docker images to only affect Conservator images.

**File Changes:**

`jenkins-pipelines/linux_desktop_build.groovy`
 - Filter docker images to delete only conservator-related images
 - Command is structured so that if it fails (e.g. if there are no images to delete) the entire build doesn't automatically fail


[[JIRA Task](https://jiracommercial.flir.com/browse/CON-2840)]
