### PR TITLE
Tweaked dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # NOTE: If a package is required for conservator-cli to run, also include it in setup.py
+graphql-core == 3.2.1; python_version<'3.7'
 wheel
 sphinx
 sgqlc >= 13; python_version>='3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # NOTE: If a package is required for conservator-cli to run, also include it in setup.py
 wheel
 sphinx
-sgqlc >= 13
+sgqlc >= 13; python_version>='3.7'
+sgqlc == 16.0; python_version<'3.7'
 click >= 8
 tqdm
 pytest

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open("README.md", "r") as fh:
 # Packages only used for developing (pytest, black, etc.) should be placed
 # in requirements.txt instead.
 INSTALL_REQUIRES = [
-    "sgqlc >= 13; python_version>'3.7'",
+    "sgqlc >= 13; python_version>='3.7'",
     "sgqlc == 16.0; python_version<'3.7'",
     "click >= 8",
     "tqdm",

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ with open("README.md", "r") as fh:
 # Packages only used for developing (pytest, black, etc.) should be placed
 # in requirements.txt instead.
 INSTALL_REQUIRES = [
+    "graphql-core == 3.2.1; python_version<'3.7'",
     "sgqlc >= 13; python_version>='3.7'",
     "sgqlc == 16.0; python_version<'3.7'",
     "click >= 8",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ with open("README.md", "r") as fh:
 # Packages only used for developing (pytest, black, etc.) should be placed
 # in requirements.txt instead.
 INSTALL_REQUIRES = [
-    "sgqlc >= 13",
+    "sgqlc >= 13; python_version>'3.7'",
+    "sgqlc == 16.0; python_version<'3.7'",
     "click >= 8",
     "tqdm",
     "requests",


### PR DESCRIPTION
Installation of Conservator-CLI was failing during Conservator build; error was:

```
Could not find a version that satisfies the requirement typing-extensions<5,>=4.2; python_version < "3.8" (from graphql-core->sgqlc>=13->conservator-cli) (from versions: 3.6.2, 3.6.2.1, 3.6.5, 3.6.6, 3.7.2, 3.7.4, 3.7.4.1, 3.7.4.2, 3.7.4.3, 3.10.0.0, 3.10.0.1, 3.10.0.2, 4.0.0, 4.0.1, 4.1.0, 4.1.1)
No matching distribution found for typing-extensions<5,>=4.2; python_version < "3.8" (from graphql-core->sgqlc>=13->conservator-cli)
The command '/bin/sh -c pip3 install conservator-cli' returned a non-zero code: 1
```
Temporary solution is to set the version of `sgqlc` to `16.0` for python < 3.7, which seems to work.
In the longer-term, we need to update the Dockerfile for Conservator to Ubuntu 20.04.

**To test:**

Replace the line:
```
RUN pip3 install conservator-cli
```
with
```
RUN pip3 install git+https://github.com/FLIR/conservator-cli.git@CON-2907_20220926_dependency_error
``` 
in Conservator's `docker/webapp/Dockerfile`, then run `./build.sh --no-cache` from the `docker/webapp` directory.


**File Changes:**

`requirements.txt`
`setup.py`
 - Require `sgqlc` version `16.0` for Python < 3.7.


[[JIRA Task](https://jiracommercial.flir.com/browse/CON-2907)]
