### PR TITLE
Added backwards compatibility for index.json with analytics fields

### DIFF
--- a/FLIR/conservator/cli/cvc.py
+++ b/FLIR/conservator/cli/cvc.py
@@ -302,7 +302,12 @@ def status(local_dataset):
 
 
 @main.command(help="Download media files from frames.jsonl or index.json")
-@click.option("-r", "--include-raw", is_flag=True)
+@click.option(
+    "-r", "--include-raw", is_flag=True, help="Include raw TIFF images, if available"
+)
+@click.option(
+    "-a", "--include-analytics", is_flag=True, help="Deprecated; use -r option instead"
+)
 @click.option(
     "-p",
     "--pool-size",
@@ -327,7 +332,7 @@ def status(local_dataset):
 )
 @pass_valid_local_dataset
 @check_git_config
-def download(local_dataset, include_raw, pool_size, symlink, tries):
+def download(local_dataset, include_raw, include_analytics, pool_size, symlink, tries):
     if pool_size == 10:  # default
         yellow = "\x1b[33;21m"
         cyan = "\x1b[36;21m"
@@ -337,8 +342,10 @@ def download(local_dataset, include_raw, pool_size, symlink, tries):
             f"this up by rerunning with the -p (--process_count) option. "
             f"For instance: {cyan}cvc download -p 50{reset}"
         )
+    if include_analytics:
+        click.echo("The -a option has been deprecated; please use -r instead.")
     download_status = local_dataset.download(
-        include_raw=include_raw,
+        include_raw=include_raw or include_analytics,
         include_eight_bit=True,
         process_count=pool_size,
         use_symlink=symlink,

--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -848,8 +848,8 @@ class LocalDataset:
                 hash_links.append(path)
                 frame_count += 1
 
-            if include_raw and ("rawMd5" in frame):
-                md5 = frame["rawMd5"]
+            if include_raw and ("rawMd5" in frame or "analyticsMd5" in frame):
+                md5 = frame["rawMd5"] if "rawMd5" in frame else frame["analyticsMd5"]
                 name = (
                     f"video-{video_id}-frame-{frame_index:06d}-{dataset_frame_id}.tiff"
                 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ graphql-core == 3.2.1; python_version<'3.7'
 wheel
 sphinx
 sphinx_rtd_theme
+myst-parser
 sgqlc >= 13; python_version>='3.7'
 sgqlc == 16.0; python_version<'3.7'
 click >= 8


### PR DESCRIPTION
 - `cvc` support for `-a`/`--include-analytics` re-added, with a note that `-a` is deprecated in favor of `-r`
 - Will download raw/analytics data for `index.json` regardless of whether the field is `rawMd5` or `analyticsMd5`
 - Added missing requirement to `requirements.txt` which was causing issues with document build

**File Changes:**

`FLIR/conservator/cli/cvc.py`
 - Re-add `-a`/`--include-analytics` options to download command

`FLIR/conservator/local_dataset.py`
 - Check both `analyticsMd5` and `rawMd5` when downloading raw TIFF data

`requirements.txt`
 - Added missing requirement `myst-parser` 


[[JIRA Task](https://jiracommercial.flir.com/browse/CON-3189)]
