### PR TITLE
Improve help text and online documentation for collection download command and improve collection dataset handling

### DIFF
--- a/FLIR/conservator/cli/managers.py
+++ b/FLIR/conservator/cli/managers.py
@@ -169,12 +169,20 @@ def get_manager_command(type_manager, sgqlc_type, name):
 
             If this operation is interrupted, repeat the command to resume
             where the previous run left off.  Partially-downloaded or
-            corrupted files will be downloaded again.
+            corrupted files will be downloaded again.  Datasets will only be
+            re-downloaded if the `--overwrite_datasets` option is supplied.
             """
         )
         @click.argument("identifier")
         @click.argument("localpath", default=".")
         @click.option("-d", "--datasets", is_flag=True, help="Pull datasets")
+        @click.option(
+            "-o",
+            "--overwrite_datasets",
+            is_flag=True,
+            help=("When pulling datasets, remove any existing cloned datasets at the destination path" +
+                  " and re-download them (BEWARE possible data loss!)")
+        )
         @click.option(
             "-v",
             "--video-metadata",
@@ -206,6 +214,7 @@ def get_manager_command(type_manager, sgqlc_type, name):
             identifier,
             localpath,
             datasets,
+            overwrite_datasets,
             video_metadata,
             associated_files,
             media,
@@ -220,6 +229,7 @@ def get_manager_command(type_manager, sgqlc_type, name):
                 video_metadata,
                 associated_files,
                 media,
+                overwrite_datasets,
                 preview_videos,
                 recursive,
             )

--- a/FLIR/conservator/cli/managers.py
+++ b/FLIR/conservator/cli/managers.py
@@ -170,7 +170,7 @@ def get_manager_command(type_manager, sgqlc_type, name):
             If this operation is interrupted, repeat the command to resume
             where the previous run left off.  Partially-downloaded or
             corrupted files will be downloaded again.  Datasets will only be
-            re-downloaded if the `--overwrite_datasets` option is supplied.
+            re-downloaded if the `--overwrite-datasets` option is supplied.
             """
         )
         @click.argument("identifier")
@@ -178,10 +178,12 @@ def get_manager_command(type_manager, sgqlc_type, name):
         @click.option("-d", "--datasets", is_flag=True, help="Pull datasets")
         @click.option(
             "-o",
-            "--overwrite_datasets",
+            "--overwrite-datasets",
             is_flag=True,
-            help=("When pulling datasets, remove any existing cloned datasets at the destination path" +
-                  " and re-download them (BEWARE possible data loss!)")
+            help=(
+                "When pulling datasets, remove any existing cloned datasets at the destination path"
+                + " and re-download them (BEWARE possible data loss!)"
+            ),
         )
         @click.option(
             "-v",

--- a/FLIR/conservator/cli/managers.py
+++ b/FLIR/conservator/cli/managers.py
@@ -163,7 +163,14 @@ def get_manager_command(type_manager, sgqlc_type, name):
             return True
 
         @group.command(
-            help="Download a Collection to the current directory, or the specified path."
+            help="""
+            Download a Collection to the current directory, or to the specified
+            path.
+
+            If this operation is interrupted, repeat the command to resume
+            where the previous run left off.  Partially-downloaded or
+            corrupted files will be downloaded again.
+            """
         )
         @click.argument("identifier")
         @click.argument("localpath", default=".")

--- a/FLIR/conservator/wrappers/collection.py
+++ b/FLIR/conservator/wrappers/collection.py
@@ -393,7 +393,8 @@ class Collection(QueryableType, FileLockerType):
                 if not os.path.isdir(clone_path):
                     logger.error(
                         "The file at '%s' has the same name as a dataset, please remove or rename it.",
-                        clone_path)
+                        clone_path,
+                    )
                     continue
                 if overwrite:
                     logger.warning("Replacing existing dataset at %s", clone_path)

--- a/docs/usage/cli_quickstart.rst
+++ b/docs/usage/cli_quickstart.rst
@@ -87,6 +87,11 @@ directory::
 
     $ conservator collections download ID -r -d -v -f -m
 
+Due to the potentially large number of files that may be present in a collection, if the
+download is interrupted before it can complete, running the same command again will
+resume the download where it left off.  Files that were partially downloaded or
+corrupted will be downloaded again.
+
 Downloading Media
 ------------------
 

--- a/docs/usage/cli_quickstart.rst
+++ b/docs/usage/cli_quickstart.rst
@@ -90,7 +90,10 @@ directory::
 Due to the potentially large number of files that may be present in a collection, if the
 download is interrupted before it can complete, running the same command again will
 resume the download where it left off.  Files that were partially downloaded or
-corrupted will be downloaded again.
+corrupted will be downloaded again.  Any existing dataset directories found in the target
+directory will not be downloaded again, unless the `--overwrite-datasets` option is
+supplied, in which case the dataset directories will be removed and re-downloaded (beware
+the risk of data loss when using this option).
 
 Downloading Media
 ------------------


### PR DESCRIPTION
Document what to expect when running the same command again after the download process is interrupted.

Add a new command-line option to allow datasets to be removed and re-downloaded.  Skip existing datasets in the target directory if the option is not present.

**File Changes:**

`FLIR/conservator/cli/managers.py`

- Add help text that appears in response to `conservator collections download --help`
- Add a new option `--overwrite-datasets` to force existing datasets in the target directory for `conservator collections download` to be removed and re-downloaded

`FLIR/conservator/wrappers/collection.py`

- Support the new `--overwrite-datasets` option for `conservator collections download`.  Existing datasets in the target directory will now be skipped if this option is not set, instead of forcing the application to exit with an error

`docs/usage/cli_quickstart.rst`

- Add a paragraph about resuming downloads following the sample command, and include text describing the handling of existing datasets found in the target directory based on the presence or absence of the `--overwrite-datasets` option

[[JIRA Task](https://jiracommercial.flir.com/browse/CON-3261)]
