### PR TITLE
Drop root privileges in Jenkins script

### DIFF
--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -4,7 +4,7 @@ pipeline {
       dir "test"
       label "docker"
       additionalBuildArgs "-t conservator-cli/test"
-      args "--init --privileged -v /var/run/docker.sock:/var/run/docker.sock"
+      args "--user tester:docker --init --privileged -v /var/run/docker.sock:/var/run/docker.sock"
     }
   }
   environment {

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -4,7 +4,7 @@ pipeline {
       dir "test"
       label "docker"
       additionalBuildArgs "-t conservator-cli/test"
-      args "-u root --init --privileged -v /var/run/docker.sock:/var/run/docker.sock"
+      args "--init --privileged -v /var/run/docker.sock:/var/run/docker.sock"
     }
   }
   environment {

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -16,6 +16,8 @@ pipeline {
         sh "pip install --no-cache-dir -r requirements.txt"
         sh "python setup.py --version"
         sh "pip install --no-cache-dir ."
+        sh "git config --global user.name 'Test User'"
+        sh "git config --global user.email 'test@example.com'"
       }
     }
     stage("Formatting Test") {

--- a/jenkins-pipelines/linux_desktop_build.groovy
+++ b/jenkins-pipelines/linux_desktop_build.groovy
@@ -4,7 +4,7 @@ pipeline {
       dir "test"
       label "docker"
       additionalBuildArgs "-t conservator-cli/test"
-      args "--user tester:docker --init --privileged -v /var/run/docker.sock:/var/run/docker.sock"
+      args "--add-host conservator-mongo:127.0.0.1 --user tester:docker --init --privileged -v /var/run/docker.sock:/var/run/docker.sock"
     }
   }
   environment {

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -45,4 +45,9 @@ RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.
 #    && unzip awscliv2.zip \
 #    && ./aws/install
 
+RUN useradd --uid 1000 --gid 999 tester
+RUN mkdir /home/tester
+RUN chown tester:docker /home/tester
+USER tester
+
 ENV RUNNING_IN_CLI_TESTING_DOCKER=True

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -50,4 +50,5 @@ RUN mkdir /home/tester
 RUN chown tester:docker /home/tester
 USER tester
 
+ENV PATH=/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin:/home/tester/.local/bin
 ENV RUNNING_IN_CLI_TESTING_DOCKER=True

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -52,3 +52,8 @@ USER tester
 
 ENV PATH=/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin:/home/tester/.local/bin
 ENV RUNNING_IN_CLI_TESTING_DOCKER=True
+
+# address "host key verification error" on clone
+RUN mkdir ~/.ssh
+RUN chmod 700 ~/.ssh
+RUN ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts

--- a/version.py
+++ b/version.py
@@ -42,7 +42,7 @@ def call_git_describe(abbrev):
         p = Popen(
             ["git", "describe", "--match", "[0-9]*", "--abbrev=%d" % abbrev],
             stdout=PIPE,
-            stderr=PIPE,
+            # stderr=PIPE,
         )
         p.stderr.close()
         line = p.stdout.readlines()[0]

--- a/version.py
+++ b/version.py
@@ -44,7 +44,7 @@ def call_git_describe(abbrev):
             stdout=PIPE,
             # stderr=PIPE,
         )
-        p.stderr.close()
+        # p.stderr.close()
         line = p.stdout.readlines()[0]
         version = line.strip().decode("utf-8")
         # Find the second -, replace it with + - otherwise pip just break

--- a/version.py
+++ b/version.py
@@ -52,7 +52,8 @@ def call_git_describe(abbrev):
         version = version.replace("-", "+", 2)
         version = version.replace("+", "-", 1)
         return version
-    except:
+    except Exception as exc:
+        print(f"git describe exception: {exc}")
         return None
 
 


### PR DESCRIPTION
Git refuses to work properly when run as root.  Run jenkins tasks as an unprivileged user inside the kind / kubernetes cluster instead.

**File Changes:**

`version.py`

- Display any exceptions encountered inside the `try:` block in `call_git_describe()` to make it easier to track down failures when collecting version information from git

`test/Dockerfile`

- Create an unprivileged user `tester` for use inside the docker image
- Make the `$HOME/.local/bin` directory available in $PATH, since that is where pip installs executables when not run as root
- Make the github.com SSH RSA host key available inside the docker image to work around a git error

`jenkins/linux_desktop_build.groovy`

- Run the docker image as the `tester` user, and create an `/etc/hosts` entry for conservator-mongo on the docker command line, since the `tester` user doesn't have write access
- Configure the git user name and email address in the install stage

[[JIRA Task](https://jiracommercial.flir.com/browse/CON-3337)]
