### PR TITLE
Work on version checking

### DIFF
--- a/FLIR/conservator/util.py
+++ b/FLIR/conservator/util.py
@@ -98,27 +98,47 @@ def get_conservator_cli_version():
 
 
 def compare_conservator_cli_version():
-    current_version = semver.VersionInfo.parse(cli_ver)
-    latest_version = semver.VersionInfo.parse(get_conservator_cli_version())
+    installed_version = semver.VersionInfo.parse(cli_ver)
+    released_version = semver.VersionInfo.parse(get_conservator_cli_version())
 
-    if latest_version == current_version:
+    installed_version_simple = semver.VersionInfo.parse(
+        f"{installed_version.major}.{installed_version.minor}.{installed_version.patch}"
+    )
+
+    if released_version == installed_version:
         return True
-    if latest_version < current_version:
-        logger.warning("You are using Conservator-cli version %s", current_version)
-        logger.warning("Please upgrade to the latest version %s", latest_version)
-        return False
-    if latest_version > current_version:
+    if released_version == installed_version_simple and installed_version.build:
         logger.warning(
             "You are using an unreleased version of Conservator-cli (%s)",
-            current_version,
+            installed_version,
         )
         logger.warning(
             "Please be aware that this version may not be supported in the future"
         )
         logger.warning(
             "For reference, the current supported version of Conservator-cli is %s",
-            latest_version,
+            released_version,
         )
+        return False
+    if released_version < installed_version_simple:
+        logger.warning(
+            "You are using an unreleased version of Conservator-cli (%s)",
+            installed_version,
+        )
+        logger.warning(
+            "Please be aware that this version may not be supported in the future"
+        )
+        logger.warning(
+            "For reference, the current supported version of Conservator-cli is %s",
+            released_version,
+        )
+        return False
+    if released_version > installed_version_simple:
+        logger.warning(
+            "You are using a deprecated version of Conservator-cli (%s)",
+            installed_version,
+        )
+        logger.warning("Please upgrade to the latest version (%s)", released_version)
         return False
 
 


### PR DESCRIPTION
The semver code was not working as expected. This has been fixed.

To test:
 - install this branch locally (`pip install .`) and test using `conservator whoami`. The message should report an unreleased version.
 - install this branch from github (`pip install git+https://github.com/FLIR/conservator-cli.git@CON-3858_20230525_fix-semver-code`) and test using `conservator whoami`. The message should report an unreleased version.
 - install this branch using either method, and then edit the installed `version.py` file to give a different version that is lower than the currently released version (2.13.0). `version.py` can be found in e.g. `venv/lib/python3.x/site-packages/FLIR/conservator`.

**File Changes:**

`FLIR/conservator/util.py`
 - Tweaked semver code to recognize unreleased builds, and identify newer/older versions correctly


[[JIRA Task](https://jiracommercial.flir.com/browse/CON-3358)]
