### PR TITLE
CON 3481 update k8s gpg url in Dockerfile

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -fsSL https://get.docker.com | sh
 # Install kubectl
 RUN apt-get update \
     && apt-get install -y apt-transport-https ca-certificates curl \
-    && curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    && curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" \
     | tee /etc/apt/sources.list.d/kubernetes.list \
     && apt-get update \


### PR DESCRIPTION
This PR updates Dockerfile with new k8s url for gpg key

**File Changed**

`test/Dockerfile`

- updated url

[[Jira Task](https://jiracommercial.flir.com/browse/CON-3481)]