### PR TITLE
CON 3421 update cli readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,3 @@ Please visit the [Official Documentation](https://flir.github.io/conservator-cli
 to get started.
 
 Conservator CLI is licensed under the [MIT License](https://opensource.org/licenses/MIT).
-
-# test

--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ Please visit the [Official Documentation](https://flir.github.io/conservator-cli
 to get started.
 
 Conservator CLI is licensed under the [MIT License](https://opensource.org/licenses/MIT).
+
+# test

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Conservator CLI
 
-[![Build Status](https://flirjenkins.com/buildStatus/icon?job=FLIR-Ubuntu/conservator-cli/main)](https://flirjenkins.com/job/FLIR-Ubuntu/job/conservator-cli/job/main/)
+[![Build Status](https://jenkins.conservator.ai/buildStatus/icon?job=conservator_cli)](https://jenkins.conservator.ai/job/conservator_cli/)
 
-This library provides a Python API to interface with 
+This library provides a Python API to interface with
 [Conservator](https://flirconservator.com/), as well as a CLI for
 simple operations like searching, downloading, and uploading files.
 

--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ Please visit the [Official Documentation](https://flir.github.io/conservator-cli
 to get started.
 
 Conservator CLI is licensed under the [MIT License](https://opensource.org/licenses/MIT).
+
+# Test


### PR DESCRIPTION
This PR updates the Conservator CLI README with the new Jenkins embed status.

**File Changed**

`README.md`

- updated url

[[Jira Task](https://jiracommercial.flir.com/browse/CON-3421)]