### PR TITLE
revert test changes to jenkins script

### DIFF
--- a/jenkins-pipelines/visgence_linux_desktop_build.groovy
+++ b/jenkins-pipelines/visgence_linux_desktop_build.groovy
@@ -1,5 +1,3 @@
-properties(pipelineTriggers([githubPullRequests(events: [Open(), commitChanged()], spec: '', triggerMode: 'HEAVY_HOOKS')]))
-
 pipeline {
   agent {
     dockerfile {


### PR DESCRIPTION
This PR reverts changes for Jenkins script testing

**File Changed**

`jenkins-pipelines/visgence_linux_desktop_build.groovy`

- reverted `pipelineTriggers` testing

[[Jira Task](https://jiracommercial.flir.com/browse/CON-3421)]