### PR TITLE
CON 2179 add error handling for symlink

### DIFF
--- a/FLIR/conservator/cli/cvc.py
+++ b/FLIR/conservator/cli/cvc.py
@@ -405,12 +405,14 @@ def download(local_dataset, include_raw, include_analytics, pool_size, symlink, 
             click.echo(
                 f"  {red}Error - Conservator cache directory (cache_dir) is on a different \
 volume, and cannot be used.{reset}"
-                )
+            )
             click.echo(
                 f"  {red}Either use the -s/--symlink flag with cvc download, or move your cache \
 directory to the same volume the dataset is on."
-                )
-            click.echo(f"  {red}See https://flir.github.io/conservator-cli/ for detail{reset}")
+            )
+            click.echo(
+                f"  {red}See https://flir.github.io/conservator-cli/ for detail{reset}"
+            )
             sys.exit(1)
 
         raise OSError from exc

--- a/FLIR/conservator/cli/cvc.py
+++ b/FLIR/conservator/cli/cvc.py
@@ -411,7 +411,9 @@ volume, and cannot be used.{reset}"
 directory to the same volume the dataset is on."
             )
             click.echo(
-                f"  {red}See https://flir.github.io/conservator-cli/ for detail{reset}"
+                f"  {red}See \
+https://flir.github.io/conservator-cli/usage/cvc_guide.html#downloading-frames \
+for details.{reset}"
             )
             sys.exit(1)
 

--- a/FLIR/conservator/cli/cvc.py
+++ b/FLIR/conservator/cli/cvc.py
@@ -389,13 +389,20 @@ def download(local_dataset, include_raw, include_analytics, pool_size, symlink, 
         )
     if include_analytics:
         click.echo("The -a option has been deprecated; please use -r instead.")
-    download_status = local_dataset.download(
-        include_raw=include_raw or include_analytics,
-        include_eight_bit=True,
-        process_count=pool_size,
-        use_symlink=symlink,
-        tries=tries,
-    )
+    try:
+        download_status = local_dataset.download(
+            include_raw=include_raw or include_analytics,
+            include_eight_bit=True,
+            process_count=pool_size,
+            use_symlink=symlink,
+            tries=tries,
+        )
+    except OSError as exc:
+        red = "\x1B[31m"
+        reset = "\x1b[0m"
+        click.echo(f"  {red}Files were downloaded but links were not created.{reset}")
+        click.echo(f"  {red}Run the command using the -s|--symlink flag.{reset}")
+        sys.exit(1)
     if not download_status:
         sys.exit(1)
 

--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -896,8 +896,8 @@ class LocalDataset:
         for attempt in range(tries):
             with multiprocessing.get_context("fork").Pool(process_count) as pool:
                 download_method = functools.partial(
-                        LocalDataset._download_and_link, self, max_retries=tries
-                    )
+                    LocalDataset._download_and_link, self, max_retries=tries
+                )
                 progress = tqdm.tqdm(
                     iterable=pool.imap(download_method, current_assets),
                     desc=progress_msg,

--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -766,10 +766,7 @@ class LocalDataset:
                 no_meter=True,
                 max_retries=max_retries,
             )
-            try:
-                LocalDataset._add_links(download_path, paths_to_link, use_symlink)
-            except OSError as exc:
-                raise OSError() from exc
+            LocalDataset._add_links(download_path, paths_to_link, use_symlink)
             return result is not None and result.ok
         except FileDownloadException:
             return False

--- a/FLIR/conservator/local_dataset.py
+++ b/FLIR/conservator/local_dataset.py
@@ -871,10 +871,7 @@ class LocalDataset:
         for md5, paths_to_link in hashes_required.items():
             cache_path = self.get_cache_path(md5)
             if self.exists_in_cache(md5):
-                try:
-                    LocalDataset._add_links(cache_path, paths_to_link, use_symlink)
-                except OSError as exc:
-                    raise OSError() from exc
+                LocalDataset._add_links(cache_path, paths_to_link, use_symlink)
                 cache_hits += 1
                 logger.debug("Skipping %s: already downloaded.", md5)
                 continue
@@ -898,12 +895,9 @@ class LocalDataset:
         progress_msg = "Downloading new frames"
         for attempt in range(tries):
             with multiprocessing.get_context("fork").Pool(process_count) as pool:
-                try:
-                    download_method = functools.partial(
+                download_method = functools.partial(
                         LocalDataset._download_and_link, self, max_retries=tries
                     )
-                except OSError as exc:
-                    raise OSError() from exc
                 progress = tqdm.tqdm(
                     iterable=pool.imap(download_method, current_assets),
                     desc=progress_msg,

--- a/docs/usage/cvc_guide.rst
+++ b/docs/usage/cvc_guide.rst
@@ -235,7 +235,7 @@ you can increase this number by using the ``--pool-size`` option (``-p`` for sho
 
 When using a global cache, it may be necessary to run the download command using the
 ``-s`` | ``--symlink`` flag which will create a symlink versus a hard link in the 
-``data/`` directory of the cloned dataset.
+``data/`` directory of the cloned dataset. (i.e. if the cache is on a different volume)
 
     $ cvc download -s 
 

--- a/docs/usage/cvc_guide.rst
+++ b/docs/usage/cvc_guide.rst
@@ -234,10 +234,10 @@ you can increase this number by using the ``--pool-size`` option (``-p`` for sho
     $ cvc download --pool-size 50  # download 50 frames at a time
 
 When using a global cache, it may be necessary to run the download command using the
-``-s`` | ``--symlink`` flag which will create a symlink versus a hard link in the 
-``data/`` directory of the cloned dataset. (i.e. if the cache is on a different volume)
+``-s`` | ``--symlink`` flag which will create a symlink versus a hard link in the
+``data/`` directory of the cloned dataset (i.e. if the cache is on a different volume).
 
-    $ cvc download -s 
+    $ cvc download -s
 
 Commit History
 ^^^^^^^^^^^^^^

--- a/docs/usage/cvc_guide.rst
+++ b/docs/usage/cvc_guide.rst
@@ -233,6 +233,12 @@ you can increase this number by using the ``--pool-size`` option (``-p`` for sho
 
     $ cvc download --pool-size 50  # download 50 frames at a time
 
+When using a global cache, it may be necessary to run the download command using the
+``-s`` | ``--symlink`` flag which will create a symlink versus a hard link in the 
+``data/`` directory of the cloned dataset.
+
+    $ cvc download -s 
+
 Commit History
 ^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This PR adds a message about using the -s flag when downloading with cvc.

**Files Changed**

`FLIR/conservator/local_dataset.py`
`FLIR/conservator/cli/cvc.py`

- added error handling and message

`docs/usage/cvc_guide.rst`

- updated docs

[[Jira Task](https://jiracommercial.flir.com/browse/CON-2179)]